### PR TITLE
Restore docker publish on main pushes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,18 +1,8 @@
 name: Publish Docker Image
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      push:
-        description: 'Push images to GHCR'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'false'
-          - 'true'
+  push:
+    branches: [ "main" ]
 
 jobs:
   build-and-publish:
@@ -105,7 +95,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: ${{ github.event_name == 'release' || inputs.push == 'true' }}
+          push: true
           tags: ghcr.io/${{ github.repository }}:mysql${{ matrix.mysql-version }}
           build-args: |
             MYSQL_VERSION=${{ matrix.mysql-version }}
@@ -116,7 +106,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: ${{ github.event_name == 'release' || inputs.push == 'true' }}
+          push: true
           tags: ghcr.io/${{ github.repository }}:latest
           build-args: |
             MYSQL_VERSION=${{ matrix.mysql-version }}


### PR DESCRIPTION
## Summary
- restore docker publish workflow trigger on main pushes
- revert manual-only release gating for image publishing

## Test plan
- [ ] CI