### PR TITLE
Fix docker workflow missing .i include

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,6 +50,7 @@ jobs:
           mkdir -p mysql-server/plugin/myvector
           cp src/*.cc mysql-server/plugin/myvector/
           cp include/*.h mysql-server/plugin/myvector/
+          cp include/*.i mysql-server/plugin/myvector/ 2>/dev/null || true
           cp CMakeLists.txt mysql-server/plugin/myvector/
 
       - name: Configure MySQL Build


### PR DESCRIPTION
## Summary
- copy `include/*.i` into the MyVector plugin directory during Docker builds

## Test plan
- [x] CI (Publish Docker Image)