### PR TITLE
Add README-based Docker smoke test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,6 +91,10 @@ jobs:
           docker run --rm myvector-smoke:${{ matrix.mysql-version }} \
             /bin/sh -c "test -f /usr/lib/mysql/plugin/myvector.so && test -f /docker-entrypoint-initdb.d/myvectorplugin.sql"
 
+      - name: Smoke test README examples
+        run: |
+          bash scripts/smoke-readme.sh myvector-smoke:${{ matrix.mysql-version }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/scripts/smoke-readme.sh
+++ b/scripts/smoke-readme.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE="${1:-myvector-smoke:local}"
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-myvector}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-vectordb}"
+CONTAINER_NAME="myvector-smoke-$$"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker run -d --rm \
+  --name "$CONTAINER_NAME" \
+  -e MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD" \
+  -e MYSQL_DATABASE="$MYSQL_DATABASE" \
+  "$IMAGE" >/dev/null
+
+echo "Waiting for MySQL to be ready..."
+for _ in $(seq 1 30); do
+  if docker exec "$CONTAINER_NAME" \
+    mysqladmin ping -uroot -p"$MYSQL_ROOT_PASSWORD" --silent >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+docker exec "$CONTAINER_NAME" \
+  mysqladmin ping -uroot -p"$MYSQL_ROOT_PASSWORD" --silent >/dev/null
+
+docker exec -i "$CONTAINER_NAME" \
+  mysql -uroot -p"$MYSQL_ROOT_PASSWORD" "$MYSQL_DATABASE" <<'SQL'
+SELECT myvector_display(myvector_construct('[1.0, 2.0, 3.0]')) AS vec;
+SELECT myvector_distance(
+  myvector_construct('[1.0, 0.0]'),
+  myvector_construct('[0.0, 1.0]'),
+  'L2'
+) AS dist_l2;
+SQL


### PR DESCRIPTION
## Summary
- add a small container smoke test that executes README example queries
- run the smoke test in the Docker publish workflow before pushing

## Test plan
- [ ] Publish Docker Image