### PR TITLE
Fix smoke test container running check

### DIFF
--- a/scripts/smoke-readme.sh
+++ b/scripts/smoke-readme.sh
@@ -18,7 +18,9 @@ docker run -d \
   "$IMAGE" >/dev/null
 
 ensure_container_running() {
-  if ! docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" >/dev/null 2>&1; then
+  local running
+  running="$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || true)"
+  if [ "$running" != "true" ]; then
     echo "Container stopped before MySQL was ready."
     docker logs "$CONTAINER_NAME" || true
     exit 1


### PR DESCRIPTION
## Summary
- check the container running state value rather than inspect exit status
- surface early container exits with logs immediately

## Test plan
- [ ] CI