### PR TITLE
Fix libstdc++ runtime mismatches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,3 +17,8 @@ MYSQL_ADD_PLUGIN(myvector
   MODULE_ONLY
   MODULE_OUTPUT_NAME "myvector"
   )
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set_property(TARGET myvector APPEND_STRING PROPERTY LINK_FLAGS
+    " -static-libstdc++ -static-libgcc")
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
 ARG MYSQL_VERSION=8.0
-FROM ubuntu:22.04 AS libstdcxx
-RUN apt-get update && apt-get install -y libstdc++6 && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /opt/libstdcxx && \
-    libstdcxx_file="$(ls /usr/lib/x86_64-linux-gnu/libstdc++.so.6.* | head -n1)" && \
-    cp -a "$libstdcxx_file" /opt/libstdcxx/ && \
-    ln -s "$(basename "$libstdcxx_file")" /opt/libstdcxx/libstdc++.so.6
-
-# Use MySQL as the base image
 FROM mysql:${MYSQL_VERSION}
 
 # Copy the MyVector plugin and installation script
@@ -16,21 +8,5 @@ RUN if [ -d /usr/lib64/mysql/plugin ]; then \
       cp /usr/lib/mysql/plugin/myvector.so /usr/lib64/mysql/plugin/; \
     fi
 COPY myvectorplugin.sql /docker-entrypoint-initdb.d/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /usr/lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /usr/lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /usr/lib/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /usr/lib/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /lib/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /lib/
-RUN libstdcxx_real="$(ls /lib64/libstdc++.so.6.* | grep -v gdb | head -n1)" && \
-    ln -sf "$(basename "$libstdcxx_real")" /lib64/libstdc++.so.6 && \
-    ln -sf "$(basename "$libstdcxx_real")" /usr/lib64/libstdc++.so.6 && \
-    ln -sf "$(basename "$libstdcxx_real")" /usr/lib/libstdc++.so.6 && \
-    ln -sf "$(basename "$libstdcxx_real")" /lib/libstdc++.so.6 && \
-    rm -f /lib64/libstdc++.so.6.*gdb* /lib/libstdc++.so.6.*gdb* \
-      /usr/lib64/libstdc++.so.6.*gdb* /usr/lib/libstdc++.so.6.*gdb* && \
-    ldconfig
 
 # The rest will be handled by the default MySQL entrypoint

--- a/Dockerfile.oraclelinux9
+++ b/Dockerfile.oraclelinux9
@@ -1,22 +1,4 @@
 ARG MYSQL_VERSION=8.0
-FROM oraclelinux:9 AS libstdcxx
-RUN dnf -y install oraclelinux-developer-release-el9 dnf-plugins-core && \
-    dnf config-manager --enable ol9_codeready_builder && \
-    dnf -y install gcc-toolset-13 && \
-    mkdir -p /opt/libstdcxx && \
-    libstdcxx_file="$(find /opt/rh -name 'libstdc++.so.6.*' -type f ! -name '*gdb.py' ! -name '*gdb.cpython*' | sort | tail -n1)" && \
-    if [ -z "$libstdcxx_file" ]; then \
-      libstdcxx_file="$(find /usr -name 'libstdc++.so.6.*' -type f ! -name '*gdb.py' ! -name '*gdb.cpython*' | sort | tail -n1)"; \
-    fi && \
-    if [ -z "$libstdcxx_file" ]; then \
-      echo "libstdc++ not found in toolset or system paths" >&2; \
-      exit 1; \
-    fi && \
-    cp -a "$libstdcxx_file" /opt/libstdcxx/ && \
-    ln -s "$(basename "$libstdcxx_file")" /opt/libstdcxx/libstdc++.so.6 && \
-    dnf clean all
-
-# Use MySQL as the base image
 FROM mysql:${MYSQL_VERSION}
 
 # Copy the MyVector plugin and installation script
@@ -26,21 +8,4 @@ RUN if [ -d /usr/lib64/mysql/plugin ]; then \
       cp /usr/lib/mysql/plugin/myvector.so /usr/lib64/mysql/plugin/; \
     fi
 COPY myvectorplugin.sql /docker-entrypoint-initdb.d/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /usr/lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /usr/lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /usr/lib/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /usr/lib/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /lib64/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6 /lib/
-COPY --from=libstdcxx /opt/libstdcxx/libstdc++.so.6.* /lib/
-RUN libstdcxx_real="$(ls /lib64/libstdc++.so.6.* | grep -v gdb | head -n1)" && \
-    ln -sf "$(basename "$libstdcxx_real")" /lib64/libstdc++.so.6 && \
-    ln -sf "$(basename "$libstdcxx_real")" /usr/lib64/libstdc++.so.6 && \
-    ln -sf "$(basename "$libstdcxx_real")" /usr/lib/libstdc++.so.6 && \
-    ln -sf "$(basename "$libstdcxx_real")" /lib/libstdc++.so.6 && \
-    rm -f /lib64/libstdc++.so.6.*gdb* /lib/libstdc++.so.6.*gdb* \
-      /usr/lib64/libstdc++.so.6.*gdb* /usr/lib/libstdc++.so.6.*gdb* && \
-    ldconfig
-
 # The rest will be handled by the default MySQL entrypoint


### PR DESCRIPTION
## Summary
- statically link libstdc++/libgcc into myvector.so to avoid GLIBCXX issues
- stop overriding libstdc++ in Docker images

## Test plan
- rerun CI (docker-publish)