### PR TITLE
Fix macOS Boost extraction in release builds

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -10,6 +10,8 @@ x86_64) ARCH="amd64" ;;
 aarch64) ARCH="arm64" ;;
 esac
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+BOOST_VERSION="1.77.0"
+BOOST_DIR="$BUILD_DIR/mysql-server/boost"
 
 # Create a temporary directory for the build
 BUILD_DIR=$(mktemp -d)
@@ -36,12 +38,27 @@ if [ "$OS" == "linux" ]; then
 	sudo apt-get install -y cmake g++ bison libssl-dev libncurses5-dev libsasl2-dev libtirpc-dev
 fi
 
+# Pre-download Boost on macOS to avoid CMake extraction issues
+if [ "$OS" == "darwin" ]; then
+	mkdir -p "$BOOST_DIR"
+	BOOST_TARBALL="boost_${BOOST_VERSION//./_}.tar.bz2"
+	BOOST_URL="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_TARBALL}"
+	if [ ! -f "$BOOST_DIR/$BOOST_TARBALL" ]; then
+		curl -L "$BOOST_URL" -o "$BOOST_DIR/$BOOST_TARBALL"
+	fi
+	tar -xjf "$BOOST_DIR/$BOOST_TARBALL" -C "$BOOST_DIR"
+fi
+
 # Configure and build
 (
 	cd "$BUILD_DIR/mysql-server"
 	mkdir bld
 	cd bld
-	cmake .. -DDOWNLOAD_BOOST=1 -DWITH_BOOST=../boost -DFORCE_INSOURCE_BUILD=1
+	if [ "$OS" == "darwin" ]; then
+		cmake .. -DDOWNLOAD_BOOST=0 -DWITH_BOOST="../boost/boost_${BOOST_VERSION//./_}" -DFORCE_INSOURCE_BUILD=1
+	else
+		cmake .. -DDOWNLOAD_BOOST=1 -DWITH_BOOST=../boost -DFORCE_INSOURCE_BUILD=1
+	fi
 	if [ "$OS" == "linux" ]; then
 		NUM_CORES=$(nproc)
 	elif [ "$OS" == "darwin" ]; then


### PR DESCRIPTION
## Summary
- Pre-download and extract Boost on macOS release builds
- Disable CMake boost download on macOS to avoid archive extraction failures

## Test plan
- [ ] Release workflow (macOS 8.0.35)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build configuration with enhanced dependency handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->