### PR TITLE
docs: add docker quick start and dataset example

### DIFF
--- a/docs/DOCKER_IMAGES.md
+++ b/docs/DOCKER_IMAGES.md
@@ -30,7 +30,7 @@ Start a container with a fresh data directory:
 
 ```bash
 docker run -d \
-  --name myvector-db \
+  --name myvector-test \
   -e MYSQL_ROOT_PASSWORD=myvector \
   -e MYSQL_DATABASE=vectordb \
   -p 3306:3306 \


### PR DESCRIPTION
## Summary
- add mysql8.4 docker quick start and plugin verification steps
- add stanford50d dataset example using remote download
- document index build connection fix via myvector.cnf

## Test plan
- [ ] N/A (docs only)

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced Installation with a Quick Start (MySQL 8.4) guide including concrete docker run commands and plugin verification
  * Added an end-to-end sample workflow: dataset setup, vector loading, index building, and similarity queries
  * Added index build connection notes covering TCP handling inside containers and restart steps for socket errors
  * Centralized operational guidance and removed reliance on external documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->