### PR TITLE
feat: add myvectorbench benchmarking pipeline (issue #85)

### DIFF
--- a/.github/workflows/myvectorbench.yml
+++ b/.github/workflows/myvectorbench.yml
@@ -291,14 +291,17 @@ jobs:
           CELL_DIR="benchmarks-branch/${{ matrix.mysql_version }}/${{ matrix.build_path }}"
           RESULT_FILE="${GIT_REF}-${TIMESTAMP}.json"
           BASELINE="${CELL_DIR}/baseline.json"
-          echo "cell_dir=${CELL_DIR}" >> "$GITHUB_OUTPUT"
-          echo "result_file=${RESULT_FILE}" >> "$GITHUB_OUTPUT"
-          echo "baseline=${BASELINE}" >> "$GITHUB_OUTPUT"
           if [ -f "${BASELINE}" ]; then
-            echo "has_baseline=true" >> "$GITHUB_OUTPUT"
+            HAS_BASELINE=true
           else
-            echo "has_baseline=false" >> "$GITHUB_OUTPUT"
+            HAS_BASELINE=false
           fi
+          {
+            echo "cell_dir=${CELL_DIR}"
+            echo "result_file=${RESULT_FILE}"
+            echo "baseline=${BASELINE}"
+            echo "has_baseline=${HAS_BASELINE}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Compare against baseline
         if: >
@@ -333,11 +336,12 @@ jobs:
           steps.download.outcome == 'success' &&
           steps.paths.outputs.has_baseline == 'false'
         run: |
-          echo "## myvectorbench — ${{ github.ref_name }} · mysql:${{ matrix.mysql_version }} · ${{ matrix.build_path }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "_NO_BASELINE: first run for this matrix cell. Results stored; no comparison performed._" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          python3 -c "
+          {
+            echo "## myvectorbench — ${{ github.ref_name }} · mysql:${{ matrix.mysql_version }} · ${{ matrix.build_path }}"
+            echo ""
+            echo "_NO_BASELINE: first run for this matrix cell. Results stored; no comparison performed._"
+            echo ""
+            python3 -c "
           import json, sys
           r = json.load(open('result.json'))
           m = r.get('metrics', {})
@@ -345,7 +349,8 @@ jobs:
           print('|--------|-------|')
           for k, v in m.items():
               print(f'| {k} | {v if v is not None else \"N/A\"} |')
-          " >> "$GITHUB_STEP_SUMMARY"
+          "
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit result to benchmarks branch
         if: >

--- a/.github/workflows/myvectorbench.yml
+++ b/.github/workflows/myvectorbench.yml
@@ -1,0 +1,371 @@
+---
+name: myvectorbench
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      mysql_version:
+        description: "MySQL version to benchmark (e.g. 8.4). Leave empty to run all."
+        required: false
+        default: ""
+      build_path:
+        description: "Build path to benchmark (plugin or component). Leave empty to run all."
+        required: false
+        default: ""
+
+permissions: read-all
+
+jobs:
+  # ── Job 1: build artifacts ───────────────────────────────────────────────────
+  build-artifacts:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mysql_version: "8.4"
+            mysql_tag: "mysql-8.4.8"
+            build_path: plugin
+          - mysql_version: "8.4"
+            mysql_tag: "mysql-8.4.8"
+            build_path: component
+          - mysql_version: "9.7"
+            mysql_tag: "mysql-9.7.0"
+            build_path: component
+
+    steps:
+      - name: Filter by workflow_dispatch inputs
+        id: filter
+        run: |
+          MV="${{ github.event.inputs.mysql_version }}"
+          BP="${{ github.event.inputs.build_path }}"
+          SKIP=false
+          if [ -n "$MV" ] && [ "$MV" != "${{ matrix.mysql_version }}" ]; then
+            SKIP=true
+          fi
+          if [ -n "$BP" ] && [ "$BP" != "${{ matrix.build_path }}" ]; then
+            SKIP=true
+          fi
+          echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.filter.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Build component (8.4)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'component' &&
+          matrix.mysql_version == '8.4'
+        run: |
+          chmod +x scripts/build-component-8.4-docker.sh
+          ./scripts/build-component-8.4-docker.sh "${{ matrix.mysql_tag }}" dist/component-${{ matrix.mysql_version }}
+
+      - name: Build component (9.7)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'component' &&
+          matrix.mysql_version == '9.7'
+        run: |
+          chmod +x scripts/build-component-9.7-docker.sh
+          ./scripts/build-component-9.7-docker.sh "${{ matrix.mysql_tag }}" dist/component-${{ matrix.mysql_version }}
+
+      - name: Install build dependencies (plugin)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'plugin'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake libssl-dev libncurses5-dev pkg-config \
+            bison libtirpc-dev libldap2-dev libsasl2-dev libudev-dev \
+            libre2-dev libcurl4-openssl-dev libprotobuf-dev protobuf-compiler
+
+      - name: Cache MySQL source (plugin)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'plugin'
+        id: cache-mysql
+        uses: actions/cache@v4
+        with:
+          path: mysql-server
+          key: mysql-source-${{ matrix.mysql_tag }}-bench-v1
+
+      - name: Clone MySQL source (plugin)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'plugin' &&
+          steps.cache-mysql.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch "${{ matrix.mysql_tag }}" \
+            https://github.com/mysql/mysql-server.git mysql-server
+
+      - name: Cache Boost (plugin)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'plugin'
+        id: cache-boost
+        uses: actions/cache@v4
+        with:
+          path: boost_cache
+          key: boost-${{ matrix.mysql_tag }}-bench-v1
+
+      - name: Copy MyVector into plugin dir
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'plugin'
+        run: |
+          mkdir -p mysql-server/plugin/myvector
+          cp src/*.cc mysql-server/plugin/myvector/
+          cp include/*.h mysql-server/plugin/myvector/
+          cp include/*.i mysql-server/plugin/myvector/ 2>/dev/null || true
+          cp CMakeLists.txt mysql-server/plugin/myvector/
+
+      - name: Configure MySQL build (plugin)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'plugin'
+        run: |
+          cd mysql-server
+          mkdir -p bld && cd bld
+          rm -f CMakeCache.txt
+          cmake .. \
+            -DDOWNLOAD_BOOST=1 \
+            -DWITH_BOOST=../../boost_cache \
+            -DWITH_UNIT_TESTS=OFF \
+            -DWITH_ROUTER=OFF \
+            -DWITH_RAPID=OFF \
+            -DWITH_NDB=OFF \
+            -DWITH_NDBCLUSTER=OFF \
+            -DWITH_EXAMPLE_STORAGE_ENGINE=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build plugin
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          matrix.build_path == 'plugin'
+        run: |
+          cd mysql-server/bld
+          make myvector -j"$(nproc)"
+          mkdir -p "$GITHUB_WORKSPACE/dist/plugin-${{ matrix.mysql_version }}"
+          cp plugin_output_directory/myvector.so \
+            "$GITHUB_WORKSPACE/dist/plugin-${{ matrix.mysql_version }}/myvector.so"
+
+      - name: Upload artifact
+        if: steps.filter.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: myvector-${{ matrix.mysql_version }}-${{ matrix.build_path }}
+          path: dist/${{ matrix.build_path }}-${{ matrix.mysql_version }}/
+          if-no-files-found: warn
+
+  # ── Job 2: benchmark ─────────────────────────────────────────────────────────
+  benchmark:
+    runs-on: ubuntu-22.04
+    needs: build-artifacts
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mysql_version: "8.4"
+            build_path: plugin
+          - mysql_version: "8.4"
+            build_path: component
+          - mysql_version: "9.7"
+            build_path: component
+
+    steps:
+      - name: Filter by workflow_dispatch inputs
+        id: filter
+        run: |
+          MV="${{ github.event.inputs.mysql_version }}"
+          BP="${{ github.event.inputs.build_path }}"
+          SKIP=false
+          if [ -n "$MV" ] && [ "$MV" != "${{ matrix.mysql_version }}" ]; then
+            SKIP=true
+          fi
+          if [ -n "$BP" ] && [ "$BP" != "${{ matrix.build_path }}" ]; then
+            SKIP=true
+          fi
+          echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.filter.outputs.skip != 'true'
+        uses: actions/checkout@v4
+
+      - name: Install Python dependencies
+        if: steps.filter.outputs.skip != 'true'
+        run: pip3 install pyyaml
+
+      - name: Download artifact
+        if: steps.filter.outputs.skip != 'true'
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: myvector-${{ matrix.mysql_version }}-${{ matrix.build_path }}
+          path: ./artifact
+
+      - name: Skip if no artifact
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'failure'
+        run: |
+          echo "No artifact found for mysql:${{ matrix.mysql_version }} ${{ matrix.build_path }} — skipping."
+          echo "This is expected for combinations that are not built (e.g. 9.7 plugin)."
+
+      - name: Run benchmark
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success'
+        env:
+          RUNNER_NAME: github-ubuntu-22.04
+        run: |
+          python3 scripts/myvectorbench.py \
+            --mysql-version "${{ matrix.mysql_version }}" \
+            --build-path "${{ matrix.build_path }}" \
+            --artifact-dir ./artifact \
+            --config myvectorbench.yml \
+            --output result.json
+
+      - name: Upload result
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-result-${{ matrix.mysql_version }}-${{ matrix.build_path }}
+          path: result.json
+          if-no-files-found: warn
+
+      - name: Checkout benchmarks branch
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success'
+        uses: actions/checkout@v4
+        with:
+          ref: benchmarks
+          path: benchmarks-branch
+          fetch-depth: 0
+
+      - name: Compute result path and check baseline
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success'
+        id: paths
+        run: |
+          GIT_REF="${GITHUB_REF_NAME}"
+          TIMESTAMP="$(date -u +%Y%m%dT%H%M%S)"
+          CELL_DIR="benchmarks-branch/${{ matrix.mysql_version }}/${{ matrix.build_path }}"
+          RESULT_FILE="${GIT_REF}-${TIMESTAMP}.json"
+          BASELINE="${CELL_DIR}/baseline.json"
+          echo "cell_dir=${CELL_DIR}" >> "$GITHUB_OUTPUT"
+          echo "result_file=${RESULT_FILE}" >> "$GITHUB_OUTPUT"
+          echo "baseline=${BASELINE}" >> "$GITHUB_OUTPUT"
+          if [ -f "${BASELINE}" ]; then
+            echo "has_baseline=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_baseline=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compare against baseline
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success' &&
+          steps.paths.outputs.has_baseline == 'true'
+        id: compare
+        run: |
+          python3 scripts/myvectorbench-compare.py \
+            "${{ steps.paths.outputs.baseline }}" \
+            result.json \
+            --config myvectorbench.yml | tee compare-output.txt
+          EXIT_CODE="${PIPESTATUS[0]}"
+          exit "${EXIT_CODE}"
+
+      - name: Post job summary (with baseline)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success' &&
+          steps.paths.outputs.has_baseline == 'true' &&
+          always()
+        run: |
+          if [ -f compare-output.txt ]; then
+            cat compare-output.txt >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Post job summary (no baseline)
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success' &&
+          steps.paths.outputs.has_baseline == 'false'
+        run: |
+          echo "## myvectorbench — ${{ github.ref_name }} · mysql:${{ matrix.mysql_version }} · ${{ matrix.build_path }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "_NO_BASELINE: first run for this matrix cell. Results stored; no comparison performed._" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          python3 -c "
+          import json, sys
+          r = json.load(open('result.json'))
+          m = r.get('metrics', {})
+          print('| Metric | Value |')
+          print('|--------|-------|')
+          for k, v in m.items():
+              print(f'| {k} | {v if v is not None else \"N/A\"} |')
+          " >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit result to benchmarks branch
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success'
+        run: |
+          CELL_DIR="${{ steps.paths.outputs.cell_dir }}"
+          RESULT_FILE="${{ steps.paths.outputs.result_file }}"
+          mkdir -p "${CELL_DIR}"
+          cp result.json "${CELL_DIR}/${RESULT_FILE}"
+          cp result.json "${CELL_DIR}/latest.json"
+
+          cd benchmarks-branch
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create README if this is the first-ever commit to the branch
+          if [ ! -f README.md ]; then
+            printf '%s\n' \
+              '# benchmarks/' \
+              '' \
+              'This branch stores myvectorbench result history for the MyVector project.' \
+              '' \
+              '## Layout' \
+              '' \
+              '```' \
+              'benchmarks/' \
+              '  <mysql_version>/' \
+              '    <build_path>/' \
+              '      <git_ref>-<timestamp>.json   -- individual run result' \
+              '      latest.json                  -- copy of most recent run' \
+              '      baseline.json                -- manually promoted baseline' \
+              '```' \
+              '' \
+              '## Baseline promotion' \
+              '' \
+              'After a release passes the pre-release gate, promote results to baseline:' \
+              '' \
+              '```bash' \
+              'python3 scripts/myvectorbench.py --promote <git-ref> --config myvectorbench.yml' \
+              'git -C <benchmarks-worktree> push origin benchmarks' \
+              '```' \
+              > README.md
+            git add README.md
+          fi
+
+          git add "${{ matrix.mysql_version }}/${{ matrix.build_path }}/${RESULT_FILE}"
+          git add "${{ matrix.mysql_version }}/${{ matrix.build_path }}/latest.json"
+          git commit -m "bench: ${{ github.ref_name }} mysql:${{ matrix.mysql_version }} ${{ matrix.build_path }}"
+          git push origin benchmarks

--- a/.github/workflows/myvectorbench.yml
+++ b/.github/workflows/myvectorbench.yml
@@ -266,7 +266,7 @@ jobs:
             git -c user.name="github-actions[bot]" \
                 -c user.email="github-actions[bot]@users.noreply.github.com" \
                 commit -m "chore: initialize benchmarks branch"
-            git push origin HEAD:benchmarks
+            git push origin HEAD:benchmarks || true  # tolerate race: another cell won
             git checkout -
           fi
 

--- a/.github/workflows/myvectorbench.yml
+++ b/.github/workflows/myvectorbench.yml
@@ -41,9 +41,12 @@ jobs:
     steps:
       - name: Filter by workflow_dispatch inputs
         id: filter
+        env:
+          INPUT_MV: ${{ github.event.inputs.mysql_version }}
+          INPUT_BP: ${{ github.event.inputs.build_path }}
         run: |
-          MV="${{ github.event.inputs.mysql_version }}"
-          BP="${{ github.event.inputs.build_path }}"
+          MV="${INPUT_MV}"
+          BP="${INPUT_BP}"
           SKIP=false
           if [ -n "$MV" ] && [ "$MV" != "${{ matrix.mysql_version }}" ]; then
             SKIP=true
@@ -163,6 +166,7 @@ jobs:
           name: myvector-${{ matrix.mysql_version }}-${{ matrix.build_path }}
           path: dist/${{ matrix.build_path }}-${{ matrix.mysql_version }}/
           if-no-files-found: warn
+          retention-days: 7
 
   # ── Job 2: benchmark ─────────────────────────────────────────────────────────
   benchmark:
@@ -184,9 +188,12 @@ jobs:
     steps:
       - name: Filter by workflow_dispatch inputs
         id: filter
+        env:
+          INPUT_MV: ${{ github.event.inputs.mysql_version }}
+          INPUT_BP: ${{ github.event.inputs.build_path }}
         run: |
-          MV="${{ github.event.inputs.mysql_version }}"
-          BP="${{ github.event.inputs.build_path }}"
+          MV="${INPUT_MV}"
+          BP="${INPUT_BP}"
           SKIP=false
           if [ -n "$MV" ] && [ "$MV" != "${{ matrix.mysql_version }}" ]; then
             SKIP=true
@@ -244,6 +251,7 @@ jobs:
           name: bench-result-${{ matrix.mysql_version }}-${{ matrix.build_path }}
           path: result.json
           if-no-files-found: warn
+          retention-days: 30
 
       - name: Checkout benchmarks branch
         if: >
@@ -282,11 +290,13 @@ jobs:
           steps.paths.outputs.has_baseline == 'true'
         id: compare
         run: |
+          set +e
           python3 scripts/myvectorbench-compare.py \
             "${{ steps.paths.outputs.baseline }}" \
             result.json \
             --config myvectorbench.yml | tee compare-output.txt
           EXIT_CODE="${PIPESTATUS[0]}"
+          set -e
           exit "${EXIT_CODE}"
 
       - name: Post job summary (with baseline)
@@ -323,7 +333,8 @@ jobs:
       - name: Commit result to benchmarks branch
         if: >
           steps.filter.outputs.skip != 'true' &&
-          steps.download.outcome == 'success'
+          steps.download.outcome == 'success' &&
+          (success() || steps.compare.outcome == 'failure')
         run: |
           CELL_DIR="${{ steps.paths.outputs.cell_dir }}"
           RESULT_FILE="${{ steps.paths.outputs.result_file }}"
@@ -368,4 +379,8 @@ jobs:
           git add "${{ matrix.mysql_version }}/${{ matrix.build_path }}/${RESULT_FILE}"
           git add "${{ matrix.mysql_version }}/${{ matrix.build_path }}/latest.json"
           git commit -m "bench: ${{ github.ref_name }} mysql:${{ matrix.mysql_version }} ${{ matrix.build_path }}"
-          git push origin benchmarks
+          for attempt in 1 2 3; do
+            git pull --rebase origin benchmarks && git push origin benchmarks && break
+            echo "Push attempt $attempt failed, retrying in 5-10s..."
+            sleep $((RANDOM % 6 + 5))
+          done

--- a/.github/workflows/myvectorbench.yml
+++ b/.github/workflows/myvectorbench.yml
@@ -304,7 +304,7 @@ jobs:
           steps.filter.outputs.skip != 'true' &&
           steps.download.outcome == 'success' &&
           steps.paths.outputs.has_baseline == 'true' &&
-          always()
+          (success() || steps.compare.outcome == 'failure')
         run: |
           if [ -f compare-output.txt ]; then
             cat compare-output.txt >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/myvectorbench.yml
+++ b/.github/workflows/myvectorbench.yml
@@ -253,6 +253,23 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+      - name: Bootstrap benchmarks branch if absent
+        if: >
+          steps.filter.outputs.skip != 'true' &&
+          steps.download.outcome == 'success'
+        run: |
+          if ! git ls-remote --exit-code origin benchmarks > /dev/null 2>&1; then
+            git checkout --orphan benchmarks
+            git reset --hard
+            printf '# benchmarks\n\nResult history written by myvectorbench CI.\n' > README.md
+            git add README.md
+            git -c user.name="github-actions[bot]" \
+                -c user.email="github-actions[bot]@users.noreply.github.com" \
+                commit -m "chore: initialize benchmarks branch"
+            git push origin HEAD:benchmarks
+            git checkout -
+          fi
+
       - name: Checkout benchmarks branch
         if: >
           steps.filter.outputs.skip != 'true' &&
@@ -381,6 +398,10 @@ jobs:
           git commit -m "bench: ${{ github.ref_name }} mysql:${{ matrix.mysql_version }} ${{ matrix.build_path }}"
           for attempt in 1 2 3; do
             git pull --rebase origin benchmarks && git push origin benchmarks && break
-            echo "Push attempt $attempt failed, retrying in 5-10s..."
+            echo "Push attempt $attempt failed, retrying..."
             sleep $((RANDOM % 6 + 5))
+            if [ "$attempt" -eq 3 ]; then
+              echo "ERROR: all push attempts exhausted" >&2
+              exit 1
+            fi
           done

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /build_fast/
 /scripts/build-fast.sh
 /src/myvector.cc.tmp
+__pycache__/
+*.pyc
+*.pyo
 # Build artifacts
 .cache/
 mysql-server/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docs/ISSUE_*_CLOSE_COMMENT.md
 
 # actionlint binary (official download script may drop this in repo root)
 /actionlint
+
+# git worktrees
+.worktrees/

--- a/myvectorbench.yml
+++ b/myvectorbench.yml
@@ -18,4 +18,4 @@ thresholds:
   insert_qps: -25%
   knn_qps: -25%
   knn_p99_ms: +30%
-  recall_at_10: -0.05        # absolute delta, not percent
+  recall_at_10: -0.05   # absolute delta — NOT YET EVALUATED: always emitted as null in v1

--- a/myvectorbench.yml
+++ b/myvectorbench.yml
@@ -1,0 +1,21 @@
+matrix:
+  mysql_versions: [8.4, 9.7]
+  build_paths: [plugin, component]
+  # A cell is skipped (not failed) if its build artifact is absent.
+  # plugin path is currently built for 8.4 only; 9.7 plugin cell is skipped.
+
+workload:
+  dataset: synthetic        # synthetic | glove50 | glove300 | /path/to/custom.tsv
+  rows: 10000
+  dim: 128
+  M: 16
+  ef_construction: 200
+  ef_search: 50
+  knn_queries: 200
+
+thresholds:
+  index_build_time_s: +25%
+  insert_qps: -25%
+  knn_qps: -25%
+  knn_p99_ms: +30%
+  recall_at_10: -0.05        # absolute delta, not percent

--- a/myvectorbench.yml
+++ b/myvectorbench.yml
@@ -10,7 +10,6 @@ workload:
   dim: 128
   M: 16
   ef_construction: 200
-  ef_search: 50
   knn_queries: 200
 
 thresholds:

--- a/scripts/myvectorbench-compare.py
+++ b/scripts/myvectorbench-compare.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Compare myvectorbench result JSON files against a baseline and check thresholds.
+
+Usage:
+  ./scripts/myvectorbench-compare.py baseline.json current.json [--config myvectorbench.yml]
+
+Exit 0: all metrics within threshold (or no baseline).
+Exit 1: one or more metrics exceeded threshold.
+"""
+
+import argparse
+import json
+import sys
+
+import yaml
+
+
+def parse_threshold(value: str):
+    """Parse a threshold string into (mode, limit).
+
+    '+25%'  → ('percent_upper',  0.25)   breach if pct_delta > 0.25
+    '-25%'  → ('percent_lower', -0.25)   breach if pct_delta < -0.25
+    '-0.05' → ('absolute',      -0.05)   breach if delta < -0.05
+    '+0.05' → ('absolute',       0.05)   breach if delta > 0.05
+    """
+    value = str(value).strip()
+    if value.endswith('%'):
+        pct = float(value[:-1]) / 100.0
+        return ('percent_upper', pct) if pct >= 0 else ('percent_lower', pct)
+    n = float(value)
+    return ('absolute', n)
+
+
+def check_threshold(baseline: float, current: float, threshold_str: str):
+    """Return (breached: bool, delta_display: float).
+
+    delta_display is pct_delta for percent thresholds, raw delta for absolute.
+    """
+    mode, limit = parse_threshold(threshold_str)
+    if baseline == 0:
+        return False, 0.0
+    pct_delta = (current - baseline) / baseline
+    delta = current - baseline
+    if mode == 'percent_upper':
+        return pct_delta > limit, pct_delta
+    if mode == 'percent_lower':
+        return pct_delta < limit, pct_delta
+    return (delta < limit if limit < 0 else delta > limit), delta
+
+
+def format_delta(delta: float, mode: str) -> str:
+    sign = '+' if delta >= 0 else ''
+    if mode.startswith('percent'):
+        return f"{sign}{delta * 100:.1f}%"
+    return f"{sign}{delta:.4f}"
+
+
+def compare(baseline_path: str, current_path: str, config_path: str) -> int:
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    thresholds = config.get('thresholds', {})
+
+    try:
+        with open(baseline_path) as f:
+            baseline = json.load(f)
+    except FileNotFoundError:
+        print(
+            f"WARNING: no baseline at {baseline_path} — NO_BASELINE, skipping comparison",
+            file=sys.stderr,
+        )
+        return 0
+
+    with open(current_path) as f:
+        current = json.load(f)
+
+    bm = baseline.get('metrics', {})
+    cm = current.get('metrics', {})
+
+    print(
+        f"## myvectorbench — {current.get('git_ref', '?')} · "
+        f"mysql:{current.get('mysql_version', '?')} · {current.get('build_path', '?')}"
+    )
+    print()
+    print(f"| {'Metric':<22} | {'Baseline':>10} | {'Current':>10} | {'Delta':>9} | Status |")
+    print(f"|{'-'*24}|{'-'*12}|{'-'*12}|{'-'*11}|--------|")
+
+    any_breach = False
+    for metric, threshold_str in thresholds.items():
+        bval = bm.get(metric)
+        cval = cm.get(metric)
+        if bval is None or cval is None:
+            print(f"| {metric:<22} | {'N/A':>10} | {'N/A':>10} | {'N/A':>9} | ⚠️   |")
+            continue
+        mode, _ = parse_threshold(threshold_str)
+        breached, delta = check_threshold(float(bval), float(cval), threshold_str)
+        delta_str = format_delta(delta, mode)
+        status = "❌" if breached else "✅"
+        if breached:
+            any_breach = True
+        print(f"| {metric:<22} | {bval:>10.4g} | {cval:>10.4g} | {delta_str:>9} | {status}   |")
+
+    print()
+    if any_breach:
+        print("FAIL: one or more metrics exceeded threshold.")
+        return 1
+    print("PASS: all metrics within threshold.")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare myvectorbench JSON results")
+    parser.add_argument("baseline", help="Path to baseline JSON")
+    parser.add_argument("current", help="Path to current result JSON")
+    parser.add_argument("--config", default="myvectorbench.yml", help="Config YAML path")
+    args = parser.parse_args()
+    sys.exit(compare(args.baseline, args.current, args.config))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/myvectorbench-compare.py
+++ b/scripts/myvectorbench-compare.py
@@ -14,6 +14,8 @@ import sys
 
 import yaml
 
+_EPS = 1e-9
+
 
 def parse_threshold(value: str):
     """Parse a threshold string into (mode, limit).
@@ -45,7 +47,7 @@ def check_threshold(baseline: float, current: float, threshold_str: str):
         return pct_delta > limit, pct_delta
     if mode == 'percent_lower':
         return pct_delta < limit, pct_delta
-    return (delta < limit if limit < 0 else delta > limit), delta
+    return (delta < limit - _EPS if limit < 0 else delta > limit + _EPS), delta
 
 
 def format_delta(delta: float, mode: str) -> str:
@@ -56,8 +58,12 @@ def format_delta(delta: float, mode: str) -> str:
 
 
 def compare(baseline_path: str, current_path: str, config_path: str) -> int:
-    with open(config_path) as f:
-        config = yaml.safe_load(f)
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"ERROR: config file not found at {config_path}", file=sys.stderr)
+        return 1
     thresholds = config.get('thresholds', {})
 
     try:
@@ -70,8 +76,12 @@ def compare(baseline_path: str, current_path: str, config_path: str) -> int:
         )
         return 0
 
-    with open(current_path) as f:
-        current = json.load(f)
+    try:
+        with open(current_path) as f:
+            current = json.load(f)
+    except FileNotFoundError:
+        print(f"ERROR: current result not found at {current_path}", file=sys.stderr)
+        return 1
 
     bm = baseline.get('metrics', {})
     cm = current.get('metrics', {})

--- a/scripts/myvectorbench-compare.py
+++ b/scripts/myvectorbench-compare.py
@@ -102,6 +102,9 @@ def compare(baseline_path: str, current_path: str, config_path: str) -> int:
             print(f"| {metric:<22} | {'N/A':>10} | {'N/A':>10} | {'N/A':>9} | ⚠️   |")
             continue
         mode, _ = parse_threshold(threshold_str)
+        if mode.startswith('percent') and float(bval) == 0:
+            print(f"| {metric:<22} | {'N/A':>10} | {'N/A':>10} | {'N/A':>9} | ⚠️   |")
+            continue
         breached, delta = check_threshold(float(bval), float(cval), threshold_str)
         delta_str = format_delta(delta, mode)
         status = "❌" if breached else "✅"

--- a/scripts/myvectorbench-compare.py
+++ b/scripts/myvectorbench-compare.py
@@ -39,15 +39,15 @@ def check_threshold(baseline: float, current: float, threshold_str: str):
     delta_display is pct_delta for percent thresholds, raw delta for absolute.
     """
     mode, limit = parse_threshold(threshold_str)
+    delta = current - baseline
+    if mode == 'absolute':
+        return (delta < limit - _EPS if limit < 0 else delta > limit + _EPS), delta
     if baseline == 0:
         return False, 0.0
-    pct_delta = (current - baseline) / baseline
-    delta = current - baseline
+    pct_delta = delta / baseline
     if mode == 'percent_upper':
         return pct_delta > limit, pct_delta
-    if mode == 'percent_lower':
-        return pct_delta < limit, pct_delta
-    return (delta < limit - _EPS if limit < 0 else delta > limit + _EPS), delta
+    return pct_delta < limit, pct_delta
 
 
 def format_delta(delta: float, mode: str) -> str:

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import os
 import random
+import statistics
 import subprocess
 import sys
 import tempfile
@@ -288,9 +289,108 @@ def load_dataset(dataset: str, wp: dict) -> list:
 
 # ── workloads (implemented in Task 3) ────────────────────────────────────────
 
+def _vec_literal(v: list) -> str:
+    """Format a float list as a myvector_construct('[...]') SQL literal."""
+    inner = ",".join(f"{x:.6f}" for x in v)
+    return f"myvector_construct('[{inner}]')"
+
+
+def _create_bench_table(container: Container, dim: int, M: int, ef: int,
+                         db: str, table: str, online: bool = False,
+                         dist: str = "L2") -> None:
+    online_flag = ",online=Y" if online else ""
+    container.sql(f"CREATE DATABASE IF NOT EXISTS {db};")
+    container.sql(f"DROP TABLE IF EXISTS {db}.{table};")
+    container.sql(
+        f"CREATE TABLE {db}.{table} ("
+        f"  id  INT PRIMARY KEY,"
+        f"  vec VARBINARY(8192)"
+        f"    COMMENT 'MYVECTOR COLUMN type=hnsw,dim={dim},size=10000,m={M},ef={ef},"
+        f"idcol=id,dist={dist}{online_flag}'"
+        f");"
+    )
+
+
+def bench_index_build(container: Container, vectors: list, wp: dict) -> float:
+    """INSERT all rows, then call MYVECTOR_INDEX_BUILD; return wall-clock seconds."""
+    dim = wp['dim']
+    M = wp.get('M', 16)
+    ef = wp.get('ef_construction', 200)
+    rows = len(vectors)
+    print(f"  [index_build] {rows} rows, dim={dim}")
+
+    _create_bench_table(container, dim, M, ef, "bench", "build_t")
+
+    batch = 500
+    for start in range(0, rows, batch):
+        chunk = vectors[start:start + batch]
+        vals = ", ".join(f"({start + i}, {_vec_literal(v)})" for i, v in enumerate(chunk))
+        container.sql(f"INSERT INTO bench.build_t (id, vec) VALUES {vals};")
+
+    t0 = time.time()
+    container.sql("CALL mysql.MYVECTOR_INDEX_BUILD('bench.build_t.vec', 'id');")
+    elapsed = time.time() - t0
+    print(f"    index_build_time_s = {elapsed:.2f}")
+    return elapsed
+
+
+def bench_insert_throughput(container: Container, vectors: list, wp: dict) -> float:
+    """INSERT rows into an online=Y indexed table; return QPS."""
+    dim = wp['dim']
+    M = wp.get('M', 16)
+    ef = wp.get('ef_construction', 200)
+    rows = len(vectors)
+    print(f"  [insert_throughput] {rows} rows, dim={dim}, online=Y")
+
+    _create_bench_table(container, dim, M, ef, "bench", "insert_t", online=True)
+
+    t0 = time.time()
+    batch = 500
+    for start in range(0, rows, batch):
+        chunk = vectors[start:start + batch]
+        vals = ", ".join(f"({start + i}, {_vec_literal(v)})" for i, v in enumerate(chunk))
+        container.sql(f"INSERT INTO bench.insert_t (id, vec) VALUES {vals};")
+    elapsed = time.time() - t0
+
+    qps = rows / elapsed if elapsed > 0 else 0.0
+    print(f"    insert_qps = {qps:.0f}")
+    return qps
+
+
+def bench_knn_search(container: Container, vectors: list, wp: dict) -> dict:
+    """Run knn_queries ORDER-BY-distance queries against build_t; return timing metrics."""
+    n_queries = wp.get('knn_queries', 200)
+    print(f"  [knn_search] {n_queries} queries, dim={wp['dim']}")
+
+    rng = random.Random(99)
+    query_vectors = [vectors[rng.randint(0, len(vectors) - 1)] for _ in range(n_queries)]
+
+    latencies_ms = []
+    for q in query_vectors:
+        sql = (
+            f"SELECT id FROM bench.build_t"
+            f" ORDER BY myvector_row_distance(vec, {_vec_literal(q)}, 'L2') LIMIT 10;"
+        )
+        t0 = time.time()
+        container.sql(sql)
+        latencies_ms.append((time.time() - t0) * 1000)
+
+    latencies_ms.sort()
+    p50 = statistics.median(latencies_ms)
+    p99 = latencies_ms[max(0, int(len(latencies_ms) * 0.99) - 1)]
+    qps = n_queries / (sum(latencies_ms) / 1000) if latencies_ms else 0.0
+    print(f"    knn_qps={qps:.0f}  p50={p50:.1f}ms  p99={p99:.1f}ms")
+    return {"knn_qps": qps, "knn_p50_ms": p50, "knn_p99_ms": p99}
+
+
 def run_workloads(container: Container, vectors: list, wp: dict,
                   build_path: str, mysql_version: str) -> dict:
-    raise NotImplementedError("workloads not yet implemented (Task 3)")
+    metrics = {}
+    metrics["index_build_time_s"] = bench_index_build(container, vectors, wp)
+    metrics["insert_qps"] = bench_insert_throughput(container, vectors, wp)
+    metrics.update(bench_knn_search(container, vectors, wp))
+    metrics["recall_at_10"] = None  # requires ANN query API not available in v1
+    return metrics
 
 
 # ── promote (implemented in Task 4) ──────────────────────────────────────────

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -12,6 +12,7 @@ Usage:
 
 import argparse
 import json
+import math
 import os
 import random
 import statistics
@@ -291,6 +292,8 @@ def load_dataset(dataset: str, wp: dict) -> list:
 
 def _vec_literal(v: list) -> str:
     """Format a float list as a myvector_construct('[...]') SQL literal."""
+    if not all(math.isfinite(x) for x in v):
+        raise ValueError(f"Vector contains non-finite value: {v[:8]}")
     inner = ",".join(f"{x:.6f}" for x in v)
     return f"myvector_construct('[{inner}]')"
 
@@ -304,7 +307,7 @@ def _create_bench_table(container: Container, dim: int, M: int, ef: int,
     container.sql(
         f"CREATE TABLE {db}.{table} ("
         f"  id  INT PRIMARY KEY,"
-        f"  vec VARBINARY(8192)"
+        f"  vec VARBINARY({dim * 4 + 8})"
         f"    COMMENT 'MYVECTOR COLUMN type=hnsw,dim={dim},size=10000,m={M},ef={ef},"
         f"idcol=id,dist={dist}{online_flag}'"
         f");"
@@ -377,7 +380,7 @@ def bench_knn_search(container: Container, vectors: list, wp: dict) -> dict:
 
     latencies_ms.sort()
     p50 = statistics.median(latencies_ms)
-    p99 = latencies_ms[max(0, int(len(latencies_ms) * 0.99) - 1)]
+    p99 = latencies_ms[max(0, math.ceil(len(latencies_ms) * 0.99) - 1)]
     qps = n_queries / (sum(latencies_ms) / 1000) if latencies_ms else 0.0
     print(f"    knn_qps={qps:.0f}  p50={p50:.1f}ms  p99={p99:.1f}ms")
     return {"knn_qps": qps, "knn_p50_ms": p50, "knn_p99_ms": p99}

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -266,6 +266,15 @@ def install_plugin(container: Container, plugin_so: str):
     data_dir = container.data_dir()
     container.cp(plugin_so, f"{plugin_dir}/myvector.so")
     container.sql("INSTALL PLUGIN myvector SONAME 'myvector.so';", "mysql")
+    container.sql(
+        "DROP FUNCTION IF EXISTS myvector_row_distance;"
+        " DROP FUNCTION IF EXISTS myvector_is_valid;"
+        " DROP FUNCTION IF EXISTS myvector_search_open_udf;"
+        " CREATE FUNCTION myvector_row_distance    RETURNS REAL    SONAME 'myvector.so';"
+        " CREATE FUNCTION myvector_is_valid        RETURNS INTEGER SONAME 'myvector.so';"
+        " CREATE FUNCTION myvector_search_open_udf RETURNS STRING  SONAME 'myvector.so';",
+        "mysql",
+    )
     try:
         container.sql(f"SET GLOBAL myvector_index_dir='{data_dir}';")
     except RuntimeError:

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -313,6 +313,7 @@ def load_dataset(dataset: str, wp: dict) -> list:
                 f"  WARNING: config dim={dim} overridden to {actual_dim} for {dataset}",
                 file=sys.stderr,
             )
+            wp['dim'] = actual_dim
         return _load_glove(dataset, rows, actual_dim)
 
     return _load_tsv(dataset, rows, dim)
@@ -386,7 +387,7 @@ def _vec_literal(v: list) -> str:
     return f"myvector_construct('[{inner}]')"
 
 
-def _create_bench_table(container: Container, dim: int, M: int, ef: int,
+def _create_bench_table(container: Container, dim: int, rows: int, M: int, ef: int,
                          db: str, table: str, online: bool = False,
                          dist: str = "L2") -> None:
     online_flag = ",online=Y" if online else ""
@@ -396,7 +397,7 @@ def _create_bench_table(container: Container, dim: int, M: int, ef: int,
         f"CREATE TABLE {db}.{table} ("
         f"  id  INT PRIMARY KEY,"
         f"  vec VARBINARY({dim * 4 + 8})"
-        f"    COMMENT 'MYVECTOR COLUMN type=hnsw,dim={dim},size=10000,m={M},ef={ef},"
+        f"    COMMENT 'MYVECTOR COLUMN type=hnsw,dim={dim},size={rows},m={M},ef={ef},"
         f"idcol=id,dist={dist}{online_flag}'"
         f");"
     )
@@ -410,7 +411,7 @@ def bench_index_build(container: Container, vectors: list, wp: dict) -> float:
     rows = len(vectors)
     print(f"  [index_build] {rows} rows, dim={dim}")
 
-    _create_bench_table(container, dim, M, ef, "bench", "build_t")
+    _create_bench_table(container, dim, rows, M, ef, "bench", "build_t")
 
     batch = 500
     for start in range(0, rows, batch):
@@ -433,7 +434,7 @@ def bench_insert_throughput(container: Container, vectors: list, wp: dict) -> fl
     rows = len(vectors)
     print(f"  [insert_throughput] {rows} rows, dim={dim}, online=Y")
 
-    _create_bench_table(container, dim, M, ef, "bench", "insert_t", online=True)
+    _create_bench_table(container, dim, rows, M, ef, "bench", "insert_t", online=True)
 
     t0 = time.time()
     batch = 500
@@ -603,7 +604,6 @@ def run_benchmark(mysql_version: str, build_path: str, artifact_dir: str,
             "dim": wp.get("dim", 128),
             "M": wp.get("M", 16),
             "ef_construction": wp.get("ef_construction", 200),
-            "ef_search": wp.get("ef_search", 50),
             "knn_queries": wp.get("knn_queries", 200),
         },
         "metrics": metrics,

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -13,11 +13,12 @@ Usage:
 import argparse
 import json
 import os
+import random
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 
 import yaml
 
@@ -47,7 +48,11 @@ class Container:
             check=True, capture_output=True,
         )
         self._running = True
-        self._wait_ready()
+        try:
+            self._wait_ready()
+        except Exception:
+            self.stop()
+            raise
         print(f"  MySQL {self.version} container ready ({self.name})")
 
     def _wait_ready(self):
@@ -90,14 +95,18 @@ class Container:
         return cmd
 
     def sql(self, sql: str, db: str = "") -> str:
-        """Execute SQL, return stdout."""
+        """Execute SQL, return stdout. Raises RuntimeError on nonzero exit."""
         r = subprocess.run(self._base_cmd(db) + ["-e", sql], capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"SQL failed (rc={r.returncode}): {r.stderr.strip()}")
         return r.stdout
 
     def sql_stdin(self, sql: str, db: str = ""):
         """Execute multi-statement SQL from stdin (handles DELIMITER)."""
-        subprocess.run(self._base_cmd(db, interactive=True),
-                       input=sql.encode(), capture_output=True)
+        r = subprocess.run(self._base_cmd(db, interactive=True),
+                           input=sql.encode(), capture_output=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"SQL (stdin) failed (rc={r.returncode}): {r.stderr.decode().strip()}")
 
     def scalar(self, sql: str, db: str = "") -> str:
         """Return last non-empty line of sql() output."""
@@ -191,12 +200,14 @@ def _ensure_libmysqlclient(container: Container):
     arch = container.exec("uname", "-m").stdout.strip()
     base = f"https://cdn.mysql.com/Downloads/MySQL-{'.'.join(srv_ver.split('.')[:2])}"
     ver_rpm = f"{srv_ver}-1.el9"
-    container.exec("bash", "-c", (
+    r = container.exec("bash", "-c", (
         f"rpm -ivh --nodeps '{base}/mysql-community-common-{ver_rpm}.{arch}.rpm' 2>/dev/null || true"
         f" && rpm -ivh --nodeps '{base}/mysql-community-client-plugins-{ver_rpm}.{arch}.rpm' 2>/dev/null || true"
         f" && rpm -ivh --nodeps '{base}/mysql-community-libs-{ver_rpm}.{arch}.rpm' 2>/dev/null"
         f" && ldconfig 2>/dev/null || true"
     ))
+    if r.returncode != 0:
+        print("  WARNING: libmysqlclient CDN install failed", file=sys.stderr)
 
 
 def install_component(container: Container, comp_dir: str):
@@ -216,11 +227,22 @@ def install_component(container: Container, comp_dir: str):
         f"myvector_user_password={container.root_pw}\n"
         f"myvector_port=3306\n"
     )
-    container.exec("bash", "-c", (
-        f"printf '%s' '{cnf}' > '{data_dir}myvector.cnf'"
-        f" && chmod 0600 '{data_dir}myvector.cnf' && chown '{owner}' '{data_dir}myvector.cnf'"
-    ))
-    container.sql(f"SET GLOBAL myvector_index_dir='{data_dir}';")
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.cnf', delete=False) as tmp:
+        tmp.write(cnf)
+        tmp_path = tmp.name
+    try:
+        container.cp(tmp_path, f"{data_dir}myvector.cnf")
+        container.cp(tmp_path, "/myvector.cnf")
+    finally:
+        os.unlink(tmp_path)
+    container.exec("bash", "-c",
+        f"chmod 0600 '{data_dir}myvector.cnf' && chown '{owner}' '{data_dir}myvector.cnf'"
+        f" && chmod 0600 /myvector.cnf && chown '{owner}' /myvector.cnf"
+    )
+    try:
+        container.sql(f"SET GLOBAL myvector_index_dir='{data_dir}';")
+    except RuntimeError:
+        pass  # sysvar not available on all versions
     container.sql(
         "DROP FUNCTION IF EXISTS myvector_row_distance;"
         " DROP FUNCTION IF EXISTS myvector_is_valid;"
@@ -240,7 +262,10 @@ def install_plugin(container: Container, plugin_so: str):
     data_dir = container.data_dir()
     container.cp(plugin_so, f"{plugin_dir}/myvector.so")
     container.sql("INSTALL PLUGIN myvector SONAME 'myvector.so';", "mysql")
-    container.sql(f"SET GLOBAL myvector_index_dir='{data_dir}';")
+    try:
+        container.sql(f"SET GLOBAL myvector_index_dir='{data_dir}';")
+    except RuntimeError:
+        pass  # sysvar not available on all versions
     container.sql_stdin(INSTALL_PROCS_SQL, "mysql")
     print("  Plugin installed.")
 
@@ -248,7 +273,6 @@ def install_plugin(container: Container, plugin_so: str):
 # ── dataset helpers ───────────────────────────────────────────────────────────
 
 def _synthetic_vectors(rows: int, dim: int, seed: int = 42) -> list:
-    import random
     rng = random.Random(seed)
     return [[rng.gauss(0, 1) for _ in range(dim)] for _ in range(rows)]
 

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -15,12 +15,14 @@ import json
 import math
 import os
 import random
+import shutil
 import statistics
 import subprocess
 import sys
 import tempfile
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import yaml
 
@@ -280,12 +282,83 @@ def _synthetic_vectors(rows: int, dim: int, seed: int = 42) -> list:
 
 
 def load_dataset(dataset: str, wp: dict) -> list:
-    """Return a list of float lists (rows × dim). Implemented fully in Task 4."""
+    """Return a list of float lists (rows × dim).
+
+    dataset values:
+      'synthetic'          — deterministic Gaussian vectors (seed=42)
+      'glove50'            — GloVe 6B 50d (downloaded to ~/.cache/myvectorbench/)
+      'glove300'           — GloVe 6B 300d
+      '/path/to/file.tsv'  — custom space/tab-separated file
+    """
     rows = wp.get("rows", 10000)
     dim = wp.get("dim", 128)
+
     if dataset == "synthetic":
         return _synthetic_vectors(rows, dim)
-    raise NotImplementedError(f"dataset '{dataset}' not yet implemented (Task 4)")
+
+    if dataset in ("glove50", "glove300"):
+        dim_map = {"glove50": 50, "glove300": 300}
+        actual_dim = dim_map[dataset]
+        if dim != actual_dim:
+            print(
+                f"  WARNING: config dim={dim} overridden to {actual_dim} for {dataset}",
+                file=sys.stderr,
+            )
+        return _load_glove(dataset, rows, actual_dim)
+
+    return _load_tsv(dataset, rows, dim)
+
+
+def _load_glove(dataset: str, rows: int, dim: int) -> list:
+    import urllib.request
+    import zipfile
+
+    filenames = {"glove50": "glove.6B.50d.txt", "glove300": "glove.6B.300d.txt"}
+    glove_url = "https://nlp.stanford.edu/data/glove.6B.zip"
+    cache_dir = Path(
+        os.environ.get("MYVECTOR_DATASET_CACHE", os.path.expanduser("~/.cache/myvectorbench"))
+    )
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    txt_path = cache_dir / filenames[dataset]
+
+    if not txt_path.exists():
+        zip_path = cache_dir / "glove.6B.zip"
+        if not zip_path.exists():
+            print(f"  Downloading GloVe 6B from {glove_url} (~860 MB) ...")
+            urllib.request.urlretrieve(glove_url, zip_path)
+        print(f"  Extracting {filenames[dataset]} ...")
+        with zipfile.ZipFile(zip_path) as z:
+            z.extract(filenames[dataset], cache_dir)
+
+    return _load_tsv(str(txt_path), rows, dim)
+
+
+def _load_tsv(path: str, rows: int, dim: int) -> list:
+    """Load up to `rows` vectors from a whitespace-separated file.
+
+    Each line is either '<word> <f1> <f2> ...' or '<f1> <f2> ...' — the
+    first non-numeric field is treated as a word token and skipped.
+    """
+    vectors = []
+    with open(path) as f:
+        for line in f:
+            if len(vectors) >= rows:
+                break
+            parts = line.strip().split()
+            if not parts:
+                continue
+            start = 0
+            try:
+                float(parts[0])
+            except ValueError:
+                start = 1
+            try:
+                v = [float(x) for x in parts[start:start + dim]]
+            except ValueError:
+                continue
+            if len(v) == dim:
+                vectors.append(v)
+    return vectors
 
 
 # ── workloads (implemented in Task 3) ────────────────────────────────────────
@@ -399,7 +472,65 @@ def run_workloads(container: Container, vectors: list, wp: dict,
 # ── promote (implemented in Task 4) ──────────────────────────────────────────
 
 def promote(git_ref: str, config_path: str):
-    raise NotImplementedError("promote not yet implemented (Task 4)")
+    """Copy git_ref result JSONs to baseline.json on the benchmarks/ branch.
+
+    Uses a temporary git worktree; requires the benchmarks/ branch to exist
+    (created by the first CI run) or origin/benchmarks to be fetchable.
+    """
+    config = load_config(config_path)
+    matrix = config.get("matrix", {})
+    mysql_versions = matrix.get("mysql_versions", [])
+    build_paths = matrix.get("build_paths", [])
+
+    with tempfile.TemporaryDirectory() as wt_dir:
+        r = subprocess.run(
+            ["git", "worktree", "add", wt_dir, "benchmarks"],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            r2 = subprocess.run(
+                ["git", "worktree", "add", "--track", "-b", "benchmarks",
+                 wt_dir, "origin/benchmarks"],
+                capture_output=True, text=True,
+            )
+            if r2.returncode != 0:
+                print(
+                    "ERROR: benchmarks/ branch does not exist locally or on origin.\n"
+                    "It is created automatically by the first CI run.\n"
+                    "Run the myvectorbench workflow at least once before promoting.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+        promoted = 0
+        for ver in mysql_versions:
+            for bp in build_paths:
+                cell_dir = Path(wt_dir) / str(ver) / bp
+                if not cell_dir.exists():
+                    print(f"  SKIP {ver}/{bp}: no results directory on benchmarks/ branch")
+                    continue
+                candidates = sorted(cell_dir.glob(f"{git_ref}-*.json"))
+                if not candidates:
+                    print(f"  SKIP {ver}/{bp}: no result file for {git_ref}")
+                    continue
+                src = candidates[-1]
+                dst = cell_dir / "baseline.json"
+                shutil.copy(src, dst)
+                print(f"  PROMOTED {ver}/{bp}: {src.name} → baseline.json")
+                promoted += 1
+
+        if promoted == 0:
+            print(f"  No results found for {git_ref} on benchmarks/ branch — nothing promoted.")
+            subprocess.run(["git", "worktree", "remove", "--force", wt_dir], capture_output=True)
+            return
+
+        subprocess.run(["git", "-C", wt_dir, "add", "-A"], check=True)
+        subprocess.run(
+            ["git", "-C", wt_dir, "commit", "-m", f"promote: set baseline to {git_ref}"],
+            check=True,
+        )
+        subprocess.run(["git", "worktree", "remove", wt_dir], check=True)
+    print(f"  Done: promoted {promoted} cell(s) to baseline for {git_ref}.")
 
 
 # ── git helper ────────────────────────────────────────────────────────────────

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""myvectorbench — benchmarking runner for MyVector.
+
+Usage:
+  ./scripts/myvectorbench.py \
+      --mysql-version 8.4 --build-path component \
+      --artifact-dir dist/component-8.4 \
+      [--config myvectorbench.yml] [--output result.json]
+
+  ./scripts/myvectorbench.py --promote <git-ref> [--config myvectorbench.yml]
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+
+# ── config ────────────────────────────────────────────────────────────────────
+
+def load_config(path: str) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+# ── Container ─────────────────────────────────────────────────────────────────
+
+class Container:
+    def __init__(self, mysql_version: str, root_pw: str = "benchroot"):
+        self.version = mysql_version
+        self.root_pw = root_pw
+        self.name = f"myvector-bench-{os.getpid()}-{mysql_version.replace('.', '')}"
+        self._running = False
+
+    def start(self):
+        subprocess.run(
+            ["docker", "run", "-d", "--name", self.name,
+             "-e", f"MYSQL_ROOT_PASSWORD={self.root_pw}",
+             "-e", "MYSQL_ROOT_HOST=%",
+             f"mysql:{self.version}"],
+            check=True, capture_output=True,
+        )
+        self._running = True
+        self._wait_ready()
+        print(f"  MySQL {self.version} container ready ({self.name})")
+
+    def _wait_ready(self):
+        ready = 0
+        for _ in range(60):
+            try:
+                r = subprocess.run(
+                    ["docker", "exec", "-e", f"MYSQL_PWD={self.root_pw}",
+                     self.name, "mysql", "-uroot", "-h127.0.0.1", "-e", "SELECT 1"],
+                    capture_output=True, timeout=5,
+                )
+                ready = ready + 1 if r.returncode == 0 else 0
+                if ready >= 3:
+                    return
+            except Exception:
+                ready = 0
+            time.sleep(2)
+        raise RuntimeError(f"MySQL {self.version} container did not become ready")
+
+    def stop(self):
+        if self._running:
+            subprocess.run(["docker", "rm", "-f", self.name], capture_output=True)
+            self._running = False
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *_):
+        self.stop()
+
+    def _base_cmd(self, db: str = "", interactive: bool = False) -> list:
+        cmd = ["docker", "exec"]
+        if interactive:
+            cmd.append("-i")
+        cmd += ["-e", f"MYSQL_PWD={self.root_pw}", self.name,
+                "mysql", "-uroot", "-h127.0.0.1", "--batch", "--silent"]
+        if db:
+            cmd += ["-D", db]
+        return cmd
+
+    def sql(self, sql: str, db: str = "") -> str:
+        """Execute SQL, return stdout."""
+        r = subprocess.run(self._base_cmd(db) + ["-e", sql], capture_output=True, text=True)
+        return r.stdout
+
+    def sql_stdin(self, sql: str, db: str = ""):
+        """Execute multi-statement SQL from stdin (handles DELIMITER)."""
+        subprocess.run(self._base_cmd(db, interactive=True),
+                       input=sql.encode(), capture_output=True)
+
+    def scalar(self, sql: str, db: str = "") -> str:
+        """Return last non-empty line of sql() output."""
+        out = self.sql(sql, db).strip()
+        return out.splitlines()[-1].strip() if out else ""
+
+    def cp(self, host_src: str, container_dst: str):
+        subprocess.run(["docker", "cp", host_src, f"{self.name}:{container_dst}"], check=True)
+
+    def exec(self, *args) -> subprocess.CompletedProcess:
+        return subprocess.run(["docker", "exec", self.name] + list(args),
+                               capture_output=True, text=True)
+
+    def plugin_dir(self) -> str:
+        return self.scalar("SELECT @@plugin_dir;")
+
+    def data_dir(self) -> str:
+        return self.scalar("SELECT @@datadir;")
+
+
+# ── stored procedures SQL (same as pre-release-test.sh install_procs) ─────────
+
+INSTALL_PROCS_SQL = """\
+DROP PROCEDURE IF EXISTS MYVECTOR_INDEX_INTERNAL;
+DROP PROCEDURE IF EXISTS MYVECTOR_INDEX_STATUS;
+DROP PROCEDURE IF EXISTS MYVECTOR_INDEX_DROP;
+DROP PROCEDURE IF EXISTS MYVECTOR_INDEX_BUILD;
+
+DELIMITER //
+
+CREATE PROCEDURE MYVECTOR_INDEX_STATUS(IN myvectorcolumn VARCHAR(256))
+BEGIN
+  DECLARE extra VARCHAR(1024); DECLARE pkid VARCHAR(1024);
+  SET extra = ''; SET pkid = '';
+  CALL MYVECTOR_INDEX_INTERNAL(myvectorcolumn, pkid, 'status', extra);
+END //
+
+CREATE PROCEDURE MYVECTOR_INDEX_DROP(IN myvectorcolumn VARCHAR(256))
+BEGIN
+  DECLARE extra VARCHAR(1024); DECLARE pkid VARCHAR(1024);
+  SET extra = ''; SET pkid = '';
+  CALL MYVECTOR_INDEX_INTERNAL(myvectorcolumn, pkid, 'drop', extra);
+END //
+
+CREATE PROCEDURE MYVECTOR_INDEX_INTERNAL(
+    IN myvectorcolumn VARCHAR(256), IN pkidcolumn VARCHAR(64),
+    IN action VARCHAR(64), IN extra VARCHAR(1024))
+BEGIN
+  DECLARE pos    INT; DECLARE status VARCHAR(1024);
+  DECLARE temp   VARCHAR(256); DECLARE dbname VARCHAR(64);
+  DECLARE tname  VARCHAR(64); DECLARE cname  VARCHAR(64);
+  DECLARE colinfo VARCHAR(1024);
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET colinfo = NULL;
+  SET pos    = LOCATE('.', myvectorcolumn);
+  SET dbname = SUBSTR(myvectorcolumn, 1, pos-1);
+  SET temp   = SUBSTR(myvectorcolumn, pos+1);
+  SET pos    = LOCATE('.', temp);
+  SET tname  = SUBSTR(temp, 1, pos-1);
+  SET cname  = SUBSTR(temp, pos+1);
+  SELECT column_comment INTO colinfo
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE table_schema = dbname AND table_name = tname AND column_name = cname;
+  IF colinfo IS NULL THEN
+    SIGNAL SQLSTATE '50001' SET MESSAGE_TEXT = 'Vector column not found.';
+  END IF;
+  IF LOCATE('MYVECTOR COLUMN', colinfo) <> 1 THEN
+    SIGNAL SQLSTATE '50002' SET MESSAGE_TEXT = 'Column is not a MYVECTOR column.';
+  END IF;
+  SET status = MYVECTOR_SEARCH_OPEN_UDF(myvectorcolumn, colinfo, pkidcolumn, action, extra);
+  SELECT status AS Status;
+END //
+
+CREATE PROCEDURE MYVECTOR_INDEX_BUILD(
+    IN myvectorcolumn VARCHAR(256), IN pkidcolumn VARCHAR(64))
+BEGIN
+  DECLARE extra VARCHAR(1024); SET extra = '';
+  CALL MYVECTOR_INDEX_INTERNAL(myvectorcolumn, pkidcolumn, 'build', extra);
+END //
+
+DELIMITER ;
+"""
+
+
+# ── install helpers ───────────────────────────────────────────────────────────
+
+def _ensure_libmysqlclient(container: Container):
+    r = container.exec("sh", "-c", "ldconfig -p 2>/dev/null | grep -q libmysqlclient")
+    if r.returncode == 0:
+        return
+    srv_ver = container.scalar("SELECT @@version;")
+    arch = container.exec("uname", "-m").stdout.strip()
+    base = f"https://cdn.mysql.com/Downloads/MySQL-{'.'.join(srv_ver.split('.')[:2])}"
+    ver_rpm = f"{srv_ver}-1.el9"
+    container.exec("bash", "-c", (
+        f"rpm -ivh --nodeps '{base}/mysql-community-common-{ver_rpm}.{arch}.rpm' 2>/dev/null || true"
+        f" && rpm -ivh --nodeps '{base}/mysql-community-client-plugins-{ver_rpm}.{arch}.rpm' 2>/dev/null || true"
+        f" && rpm -ivh --nodeps '{base}/mysql-community-libs-{ver_rpm}.{arch}.rpm' 2>/dev/null"
+        f" && ldconfig 2>/dev/null || true"
+    ))
+
+
+def install_component(container: Container, comp_dir: str):
+    """Install MyVector component build into the container."""
+    _ensure_libmysqlclient(container)
+    plugin_dir = container.plugin_dir()
+    data_dir = container.data_dir()
+
+    container.cp(f"{comp_dir}/libmyvector_component.so", f"{plugin_dir}/myvector.so")
+    container.cp(f"{comp_dir}/myvector.json", f"{plugin_dir}/myvector.json")
+    container.sql("INSTALL COMPONENT 'file://myvector';")
+
+    owner = container.exec("stat", "-c", "%U", data_dir).stdout.strip() or "mysql"
+    cnf = (
+        f"myvector_host=127.0.0.1\n"
+        f"myvector_user_id=root\n"
+        f"myvector_user_password={container.root_pw}\n"
+        f"myvector_port=3306\n"
+    )
+    container.exec("bash", "-c", (
+        f"printf '%s' '{cnf}' > '{data_dir}myvector.cnf'"
+        f" && chmod 0600 '{data_dir}myvector.cnf' && chown '{owner}' '{data_dir}myvector.cnf'"
+    ))
+    container.sql(f"SET GLOBAL myvector_index_dir='{data_dir}';")
+    container.sql(
+        "DROP FUNCTION IF EXISTS myvector_row_distance;"
+        " DROP FUNCTION IF EXISTS myvector_is_valid;"
+        " DROP FUNCTION IF EXISTS myvector_search_open_udf;"
+        " CREATE FUNCTION myvector_row_distance    RETURNS REAL    SONAME 'myvector.so';"
+        " CREATE FUNCTION myvector_is_valid        RETURNS INTEGER SONAME 'myvector.so';"
+        " CREATE FUNCTION myvector_search_open_udf RETURNS STRING  SONAME 'myvector.so';",
+        "mysql",
+    )
+    container.sql_stdin(INSTALL_PROCS_SQL, "mysql")
+    print("  Component installed.")
+
+
+def install_plugin(container: Container, plugin_so: str):
+    """Install MyVector plugin build into the container."""
+    plugin_dir = container.plugin_dir()
+    data_dir = container.data_dir()
+    container.cp(plugin_so, f"{plugin_dir}/myvector.so")
+    container.sql("INSTALL PLUGIN myvector SONAME 'myvector.so';", "mysql")
+    container.sql(f"SET GLOBAL myvector_index_dir='{data_dir}';")
+    container.sql_stdin(INSTALL_PROCS_SQL, "mysql")
+    print("  Plugin installed.")
+
+
+# ── dataset helpers ───────────────────────────────────────────────────────────
+
+def _synthetic_vectors(rows: int, dim: int, seed: int = 42) -> list:
+    import random
+    rng = random.Random(seed)
+    return [[rng.gauss(0, 1) for _ in range(dim)] for _ in range(rows)]
+
+
+def load_dataset(dataset: str, wp: dict) -> list:
+    """Return a list of float lists (rows × dim). Implemented fully in Task 4."""
+    rows = wp.get("rows", 10000)
+    dim = wp.get("dim", 128)
+    if dataset == "synthetic":
+        return _synthetic_vectors(rows, dim)
+    raise NotImplementedError(f"dataset '{dataset}' not yet implemented (Task 4)")
+
+
+# ── workloads (implemented in Task 3) ────────────────────────────────────────
+
+def run_workloads(container: Container, vectors: list, wp: dict,
+                  build_path: str, mysql_version: str) -> dict:
+    raise NotImplementedError("workloads not yet implemented (Task 3)")
+
+
+# ── promote (implemented in Task 4) ──────────────────────────────────────────
+
+def promote(git_ref: str, config_path: str):
+    raise NotImplementedError("promote not yet implemented (Task 4)")
+
+
+# ── git helper ────────────────────────────────────────────────────────────────
+
+def _git_ref() -> str:
+    try:
+        r = subprocess.run(
+            ["git", "describe", "--tags", "--always"],
+            capture_output=True, text=True, check=True,
+        )
+        return r.stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+# ── main benchmark orchestration ─────────────────────────────────────────────
+
+def run_benchmark(mysql_version: str, build_path: str, artifact_dir: str,
+                  config: dict, output: str):
+    wp = config.get('workload', {})
+    git_ref = _git_ref()
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    runner = os.environ.get("RUNNER_NAME", "local")
+    dataset = wp.get("dataset", "synthetic")
+
+    print(f"=== myvectorbench: mysql:{mysql_version} {build_path} @ {git_ref} ===")
+
+    with Container(mysql_version) as c:
+        if build_path == "component":
+            install_component(c, artifact_dir)
+        else:
+            install_plugin(c, os.path.join(artifact_dir, "myvector.so"))
+
+        vectors = load_dataset(dataset, wp)
+        metrics = run_workloads(c, vectors, wp, build_path, mysql_version)
+
+    result = {
+        "git_ref": git_ref,
+        "mysql_version": mysql_version,
+        "build_path": build_path,
+        "timestamp": timestamp,
+        "runner": runner,
+        "dataset": dataset,
+        "workload_params": {
+            "rows": wp.get("rows", 10000),
+            "dim": wp.get("dim", 128),
+            "M": wp.get("M", 16),
+            "ef_construction": wp.get("ef_construction", 200),
+            "ef_search": wp.get("ef_search", 50),
+            "knn_queries": wp.get("knn_queries", 200),
+        },
+        "metrics": metrics,
+    }
+
+    with open(output, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"  Result written to {output}")
+    print(f"  Metrics: {json.dumps(metrics, indent=2)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="myvectorbench runner")
+    parser.add_argument("--mysql-version", help="MySQL version, e.g. 8.4")
+    parser.add_argument("--build-path", choices=["component", "plugin"])
+    parser.add_argument("--artifact-dir", help="Dir containing build artifacts")
+    parser.add_argument("--config", default="myvectorbench.yml")
+    parser.add_argument("--output", default="result.json")
+    parser.add_argument("--promote", metavar="GIT_REF",
+                        help="Promote GIT_REF results to baseline on benchmarks/ branch")
+    args = parser.parse_args()
+
+    if args.promote:
+        promote(args.promote, args.config)
+        return
+
+    if not all([args.mysql_version, args.build_path, args.artifact_dir]):
+        parser.error("--mysql-version, --build-path, and --artifact-dir are required")
+
+    config = load_config(args.config)
+    run_benchmark(args.mysql_version, args.build_path, args.artifact_dir, config, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -325,7 +325,13 @@ def _load_glove(dataset: str, rows: int, dim: int) -> list:
         zip_path = cache_dir / "glove.6B.zip"
         if not zip_path.exists():
             print(f"  Downloading GloVe 6B from {glove_url} (~860 MB) ...")
-            urllib.request.urlretrieve(glove_url, zip_path)
+            zip_tmp = zip_path.with_suffix(".zip.tmp")
+            try:
+                urllib.request.urlretrieve(glove_url, zip_tmp)
+                zip_tmp.rename(zip_path)
+            except Exception:
+                zip_tmp.unlink(missing_ok=True)
+                raise
         print(f"  Extracting {filenames[dataset]} ...")
         with zipfile.ZipFile(zip_path) as z:
             z.extract(filenames[dataset], cache_dir)
@@ -356,7 +362,7 @@ def _load_tsv(path: str, rows: int, dim: int) -> list:
                 v = [float(x) for x in parts[start:start + dim]]
             except ValueError:
                 continue
-            if len(v) == dim:
+            if len(v) == dim and all(math.isfinite(x) for x in v):
                 vectors.append(v)
     return vectors
 
@@ -477,6 +483,11 @@ def promote(git_ref: str, config_path: str):
     Uses a temporary git worktree; requires the benchmarks/ branch to exist
     (created by the first CI run) or origin/benchmarks to be fetchable.
     """
+    r0 = subprocess.run(["git", "rev-parse", "--git-dir"], capture_output=True, text=True)
+    if r0.returncode != 0:
+        print("ERROR: not inside a git repository.", file=sys.stderr)
+        sys.exit(1)
+
     config = load_config(config_path)
     matrix = config.get("matrix", {})
     mysql_versions = matrix.get("mysql_versions", [])
@@ -524,12 +535,16 @@ def promote(git_ref: str, config_path: str):
             subprocess.run(["git", "worktree", "remove", "--force", wt_dir], capture_output=True)
             return
 
-        subprocess.run(["git", "-C", wt_dir, "add", "-A"], check=True)
-        subprocess.run(
-            ["git", "-C", wt_dir, "commit", "-m", f"promote: set baseline to {git_ref}"],
-            check=True,
-        )
-        subprocess.run(["git", "worktree", "remove", wt_dir], check=True)
+        try:
+            subprocess.run(["git", "-C", wt_dir, "add", "-A"], check=True)
+            subprocess.run(
+                ["git", "-C", wt_dir, "commit", "-m", f"promote: set baseline to {git_ref}"],
+                check=True,
+            )
+            subprocess.run(["git", "worktree", "remove", wt_dir], check=True)
+        except Exception:
+            subprocess.run(["git", "worktree", "remove", "--force", wt_dir], capture_output=True)
+            raise
     print(f"  Done: promoted {promoted} cell(s) to baseline for {git_ref}.")
 
 

--- a/tests/test_myvectorbench_compare.py
+++ b/tests/test_myvectorbench_compare.py
@@ -116,6 +116,9 @@ def test_compare_all_pass(capsys):
             "  recall_at_10: -0.05\n"
         )
         rc = compare(baseline, current, cfg)
+        captured = capsys.readouterr()
+    assert "PASS: all metrics within threshold." in captured.out
+    assert "## myvectorbench" in captured.out
     assert rc == 0
 
 
@@ -125,6 +128,8 @@ def test_compare_breach(capsys):
         current = _make_json(tmp, 'current.json', {'insert_qps': 300})  # -31.8%
         cfg = _make_config(tmp, "  insert_qps: -25%\n")
         rc = compare(baseline, current, cfg)
+        captured = capsys.readouterr()
+    assert "FAIL: one or more metrics exceeded threshold." in captured.out
     assert rc == 1
 
 
@@ -133,4 +138,6 @@ def test_compare_no_baseline(capsys):
         current = _make_json(tmp, 'current.json', {'insert_qps': 440})
         cfg = _make_config(tmp, "  insert_qps: -25%\n")
         rc = compare(os.path.join(tmp, 'nonexistent.json'), current, cfg)
+        captured = capsys.readouterr()
+    assert "NO_BASELINE" in captured.err
     assert rc == 0  # missing baseline → NO_BASELINE, not a failure

--- a/tests/test_myvectorbench_compare.py
+++ b/tests/test_myvectorbench_compare.py
@@ -1,0 +1,136 @@
+import importlib.util
+import json
+import os
+import tempfile
+import pytest
+
+
+def _load_compare():
+    path = os.path.join(os.path.dirname(__file__), '..', 'scripts', 'myvectorbench-compare.py')
+    spec = importlib.util.spec_from_file_location("myvectorbench_compare", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+compare_mod = _load_compare()
+parse_threshold = compare_mod.parse_threshold
+check_threshold = compare_mod.check_threshold
+compare = compare_mod.compare
+
+
+def test_parse_threshold_percent_upper():
+    mode, val = parse_threshold('+25%')
+    assert mode == 'percent_upper'
+    assert abs(val - 0.25) < 1e-9
+
+
+def test_parse_threshold_percent_lower():
+    mode, val = parse_threshold('-25%')
+    assert mode == 'percent_lower'
+    assert abs(val - (-0.25)) < 1e-9
+
+
+def test_parse_threshold_absolute_negative():
+    mode, val = parse_threshold('-0.05')
+    assert mode == 'absolute'
+    assert abs(val - (-0.05)) < 1e-9
+
+
+def test_check_no_breach_percent_upper():
+    breached, _ = check_threshold(100.0, 120.0, '+25%')
+    assert not breached
+
+
+def test_check_breach_percent_upper():
+    breached, _ = check_threshold(100.0, 130.0, '+25%')
+    assert breached
+
+
+def test_check_no_breach_percent_lower():
+    # 440 → 338 is -23.2%, within the -25% threshold
+    breached, _ = check_threshold(440.0, 338.0, '-25%')
+    assert not breached
+
+
+def test_check_breach_percent_lower():
+    # 440 → 320 is -27.3%, exceeds the -25% threshold
+    breached, _ = check_threshold(440.0, 320.0, '-25%')
+    assert breached
+
+
+def test_check_no_breach_absolute():
+    # delta = -0.042, within -0.05
+    breached, _ = check_threshold(0.942, 0.900, '-0.05')
+    assert not breached
+
+
+def test_check_breach_absolute():
+    # delta = -0.062, exceeds -0.05
+    breached, _ = check_threshold(0.942, 0.880, '-0.05')
+    assert breached
+
+
+def _make_json(tmp, name, metrics):
+    path = os.path.join(tmp, name)
+    data = {
+        "git_ref": "v1.26.5.1",
+        "mysql_version": "8.4",
+        "build_path": "component",
+        "timestamp": "2026-05-24T08:30:00Z",
+        "runner": "test",
+        "dataset": "synthetic",
+        "workload_params": {"rows": 10000, "dim": 128},
+        "metrics": metrics,
+    }
+    with open(path, 'w') as f:
+        json.dump(data, f)
+    return path
+
+
+def _make_config(tmp, thresholds_yaml):
+    path = os.path.join(tmp, 'myvectorbench.yml')
+    with open(path, 'w') as f:
+        f.write(f"thresholds:\n{thresholds_yaml}\n")
+    return path
+
+
+def test_compare_all_pass(capsys):
+    with tempfile.TemporaryDirectory() as tmp:
+        baseline = _make_json(tmp, 'baseline.json', {
+            'index_build_time_s': 12.0,
+            'insert_qps': 440,
+            'knn_p99_ms': 3.2,
+            'recall_at_10': 0.942,
+        })
+        current = _make_json(tmp, 'current.json', {
+            'index_build_time_s': 12.8,   # +6.7%, under +25%
+            'insert_qps': 435,            # -1.1%, under -25%
+            'knn_p99_ms': 3.4,            # +6.3%, under +30%
+            'recall_at_10': 0.940,        # -0.002, under -0.05
+        })
+        cfg = _make_config(tmp,
+            "  index_build_time_s: +25%\n"
+            "  insert_qps: -25%\n"
+            "  knn_p99_ms: +30%\n"
+            "  recall_at_10: -0.05\n"
+        )
+        rc = compare(baseline, current, cfg)
+    assert rc == 0
+
+
+def test_compare_breach(capsys):
+    with tempfile.TemporaryDirectory() as tmp:
+        baseline = _make_json(tmp, 'baseline.json', {'insert_qps': 440})
+        current = _make_json(tmp, 'current.json', {'insert_qps': 300})  # -31.8%
+        cfg = _make_config(tmp, "  insert_qps: -25%\n")
+        rc = compare(baseline, current, cfg)
+    assert rc == 1
+
+
+def test_compare_no_baseline(capsys):
+    with tempfile.TemporaryDirectory() as tmp:
+        current = _make_json(tmp, 'current.json', {'insert_qps': 440})
+        cfg = _make_config(tmp, "  insert_qps: -25%\n")
+        rc = compare(os.path.join(tmp, 'nonexistent.json'), current, cfg)
+    assert rc == 0  # missing baseline → NO_BASELINE, not a failure

--- a/tests/test_myvectorbench_compare.py
+++ b/tests/test_myvectorbench_compare.py
@@ -100,18 +100,21 @@ def test_compare_all_pass(capsys):
         baseline = _make_json(tmp, 'baseline.json', {
             'index_build_time_s': 12.0,
             'insert_qps': 440,
+            'knn_qps': 810,
             'knn_p99_ms': 3.2,
             'recall_at_10': 0.942,
         })
         current = _make_json(tmp, 'current.json', {
             'index_build_time_s': 12.8,   # +6.7%, under +25%
             'insert_qps': 435,            # -1.1%, under -25%
+            'knn_qps': 810,               # 0%, well within -25%
             'knn_p99_ms': 3.4,            # +6.3%, under +30%
             'recall_at_10': 0.940,        # -0.002, under -0.05
         })
         cfg = _make_config(tmp,
             "  index_build_time_s: +25%\n"
             "  insert_qps: -25%\n"
+            "  knn_qps: -25%\n"
             "  knn_p99_ms: +30%\n"
             "  recall_at_10: -0.05\n"
         )
@@ -127,6 +130,17 @@ def test_compare_breach(capsys):
         baseline = _make_json(tmp, 'baseline.json', {'insert_qps': 440})
         current = _make_json(tmp, 'current.json', {'insert_qps': 300})  # -31.8%
         cfg = _make_config(tmp, "  insert_qps: -25%\n")
+        rc = compare(baseline, current, cfg)
+        captured = capsys.readouterr()
+    assert "FAIL: one or more metrics exceeded threshold." in captured.out
+    assert rc == 1
+
+
+def test_compare_knn_qps_breach(capsys):
+    with tempfile.TemporaryDirectory() as tmp:
+        baseline = _make_json(tmp, 'baseline.json', {'knn_qps': 810})
+        current = _make_json(tmp, 'current.json', {'knn_qps': 600})  # -25.9%, exceeds -25%
+        cfg = _make_config(tmp, "  knn_qps: -25%\n")
         rc = compare(baseline, current, cfg)
         captured = capsys.readouterr()
     assert "FAIL: one or more metrics exceeded threshold." in captured.out


### PR DESCRIPTION
## Summary

- Adds `scripts/myvectorbench.py` — Docker-orchestrated benchmark runner measuring index build time, insert throughput, KNN search QPS/latency, and recall across MySQL 8.4 and 9.7 (plugin + component build paths)
- Adds `scripts/myvectorbench-compare.py` — comparator that reads a baseline JSON and a current JSON, checks per-metric thresholds (percent upper/lower and absolute), prints a markdown delta table, and exits 1 on regression
- Adds `.github/workflows/myvectorbench.yml` — CI workflow triggered on `v*` tags and `workflow_dispatch`; builds artifacts, runs benchmarks, stores results on the `benchmarks/` branch, posts a job summary, and flags regressions

## Files changed

| File | Change |
|---|---|
| `scripts/myvectorbench.py` | New — runner: Docker orchestration, 4 workloads, JSON output, GloVe/TSV dataset support, `--promote` baseline command |
| `scripts/myvectorbench-compare.py` | New — comparator: threshold enforcement, markdown table, exit codes |
| `myvectorbench.yml` | New — config: matrix, workload params, per-metric thresholds |
| `tests/test_myvectorbench_compare.py` | New — 13 unit tests for comparator logic |
| `.github/workflows/myvectorbench.yml` | New — CI workflow |
| `.gitignore` | Add `__pycache__/`, `*.pyc`, `*.pyo` |

## Test plan

- [x] 13/13 unit tests pass (`pytest tests/test_myvectorbench_compare.py`)
- [x] actionlint clean on `.github/workflows/myvectorbench.yml`
- [x] YAML valid on both `myvectorbench.yml` and the workflow
- [ ] Trigger `workflow_dispatch` on a branch after merge to verify end-to-end Docker run
- [ ] Verify `benchmarks/` branch is bootstrapped on first workflow run
- [ ] Run `./scripts/myvectorbench.py --promote <ref>` after a successful run to confirm baseline promotion

## Notes

- `recall_at_10` is always emitted as `null` in v1 (ANN vs brute-force API not exposed); threshold config documents this with a comment
- The `9.7/plugin` matrix cell is intentionally absent (no plugin build exists for 9.7)
- Baseline promotion is manual: `./scripts/myvectorbench.py --promote <git-ref>`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)