### PR TITLE
fix: HNSW type case-insensitivity + recall_at_10 workload

### DIFF
--- a/myvectorbench.yml
+++ b/myvectorbench.yml
@@ -12,13 +12,14 @@ workload:
   ef_construction: 200
   knn_queries: 200
   knn_ann_queries: 200
+  recall_queries: 50
 
 thresholds:
   index_build_time_s: +25%
   insert_qps: -25%
   knn_qps: -25%
   knn_p99_ms: +30%
-  recall_at_10: -0.05   # absolute delta — NOT YET EVALUATED: always emitted as null in v1
+  recall_at_10: -0.05   # absolute delta
   knn_ann_qps: -25%
   knn_ann_p50_ms: +30%
   knn_ann_p99_ms: +30%

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -540,6 +540,68 @@ def bench_knn_ann(container: Container, vectors: list, wp: dict) -> dict:
     return {"knn_ann_qps": qps, "knn_ann_p50_ms": p50, "knn_ann_p99_ms": p99}
 
 
+def bench_recall(container: Container, vectors: list, wp: dict) -> dict:
+    """Measure recall@10: fraction of true KNN top-10 found by ANN, averaged over queries.
+
+    Returns recall_at_10=None when MYVECTOR_IS_ANN is inactive (plugin path or
+    component without query rewrite service).
+    """
+    n_queries = min(wp.get('recall_queries', 50), len(vectors))
+    print(f"  [recall] {n_queries} queries, dim={wp['dim']}")
+
+    # Same probe used by bench_knn_ann to detect inactive query rewrite.
+    probe_supported = True
+    try:
+        container.sql(
+            "SELECT MYVECTOR_IS_ANN('bench.build_t.vec', 'id', myvector_construct('[0]'))"
+            " FROM bench.build_t LIMIT 0;",
+            db="bench",
+        )
+    except RuntimeError as e:
+        if "does not exist" in str(e) and "FUNCTION" in str(e):
+            probe_supported = False
+
+    if not probe_supported:
+        print("    ⚠ MYVECTOR_IS_ANN not supported — recall_at_10=None")
+        return {"recall_at_10": None}
+
+    rng = random.Random(42)
+    query_vectors = [vectors[rng.randint(0, len(vectors) - 1)] for _ in range(n_queries)]
+
+    recalls = []
+    for q in query_vectors:
+        # Ground truth: brute-force top-10 by distance.
+        knn_sql = (
+            f"SELECT id FROM bench.build_t"
+            f" ORDER BY myvector_distance(vec, {_vec_literal(q)}, 'L2') LIMIT 10;"
+        )
+        knn_out = container.sql(knn_sql)
+        knn_ids = {
+            int(line) for line in knn_out.strip().splitlines()[1:] if line.strip()
+        }
+
+        # ANN top-10 via query rewrite.
+        ann_sql = (
+            f"SELECT id FROM bench.build_t"
+            f" WHERE MYVECTOR_IS_ANN('bench.build_t.vec', 'id', {_vec_literal(q)}, 10);"
+        )
+        try:
+            ann_out = container.sql(ann_sql)
+            ann_ids = {
+                int(line) for line in ann_out.strip().splitlines()[1:] if line.strip()
+            }
+        except RuntimeError:
+            ann_ids = set()
+
+        if knn_ids:
+            recalls.append(len(knn_ids & ann_ids) / len(knn_ids))
+
+    recall = sum(recalls) / len(recalls) if recalls else None
+    if recall is not None:
+        print(f"    recall_at_10={recall:.3f}")
+    return {"recall_at_10": recall}
+
+
 def run_workloads(container: Container, vectors: list, wp: dict,
                   build_path: str, mysql_version: str) -> dict:
     metrics = {}
@@ -547,7 +609,7 @@ def run_workloads(container: Container, vectors: list, wp: dict,
     metrics["insert_qps"] = bench_insert_throughput(container, vectors, wp)
     metrics.update(bench_knn_search(container, vectors, wp))
     metrics.update(bench_knn_ann(container, vectors, wp))
-    metrics["recall_at_10"] = None  # requires ANN query API not available in v1
+    metrics.update(bench_recall(container, vectors, wp))
     return metrics
 
 
@@ -697,6 +759,7 @@ def run_benchmark(mysql_version: str, build_path: str, artifact_dir: str,
             "ef_construction": wp.get("ef_construction", 200),
             "knn_queries": wp.get("knn_queries", 200),
             "knn_ann_queries": wp.get("knn_ann_queries", 200),
+            "recall_queries": wp.get("recall_queries", 50),
         },
         "metrics": metrics,
     }

--- a/scripts/myvectorbench.py
+++ b/scripts/myvectorbench.py
@@ -583,15 +583,13 @@ def bench_recall(container: Container, vectors: list, wp: dict) -> dict:
         # ANN top-10 via query rewrite.
         ann_sql = (
             f"SELECT id FROM bench.build_t"
-            f" WHERE MYVECTOR_IS_ANN('bench.build_t.vec', 'id', {_vec_literal(q)}, 10);"
+            f" WHERE MYVECTOR_IS_ANN('bench.build_t.vec', 'id', {_vec_literal(q)})"
+            f" ORDER BY myvector_row_distance(id) LIMIT 10;"
         )
-        try:
-            ann_out = container.sql(ann_sql)
-            ann_ids = {
-                int(line) for line in ann_out.strip().splitlines()[1:] if line.strip()
-            }
-        except RuntimeError:
-            ann_ids = set()
+        ann_out = container.sql(ann_sql)
+        ann_ids = {
+            int(line) for line in ann_out.strip().splitlines()[1:] if line.strip()
+        }
 
         if knn_ids:
             recalls.append(len(knn_ids & ann_ids) / len(knn_ids))

--- a/src/myvector.cc
+++ b/src/myvector.cc
@@ -1104,7 +1104,8 @@ AbstractVectorIndex* VectorIndexCollection::open(const string& name,
 
     MyVectorOptions vopt(options);
     string itype = vopt.getOption("type");
-    transform(itype.begin(), itype.end(), itype.begin(), ::toupper);
+    transform(itype.begin(), itype.end(), itype.begin(),
+              [](unsigned char c) { return static_cast<char>(toupper(c)); });
 
     if (itype == "HNSW" || itype == "HNSW_BV") {
         hnewindex = new HNSWMemoryIndex(name, options);
@@ -1244,7 +1245,8 @@ bool rewriteMyVectorColumnDef(const string& query, string& newQuery) {
             vtype = "KNN";
             vo.setOption("type", vtype);
         } else {
-            transform(vtype.begin(), vtype.end(), vtype.begin(), ::toupper);
+            transform(vtype.begin(), vtype.end(), vtype.begin(),
+                      [](unsigned char c) { return static_cast<char>(toupper(c)); });
         }
 
         if (vo.getOption("dim") == "") {

--- a/src/myvector.cc
+++ b/src/myvector.cc
@@ -1102,10 +1102,13 @@ AbstractVectorIndex* VectorIndexCollection::open(const string& name,
 
     AbstractVectorIndex* hnewindex = nullptr;
 
-    /* First case handles both HNSW and HNSW_BV */
-    if (options.rfind("type=HNSW") != string::npos) {
+    MyVectorOptions vopt(options);
+    string itype = vopt.getOption("type");
+    transform(itype.begin(), itype.end(), itype.begin(), ::toupper);
+
+    if (itype == "HNSW" || itype == "HNSW_BV") {
         hnewindex = new HNSWMemoryIndex(name, options);
-    } else if (options.rfind("type=KNN") != string::npos) {
+    } else if (itype == "KNN") {
         hnewindex = new KNNIndex(name, options);
     } else {
         MYVEC_LOG_ERROR("MyVector unknown index type for %s options = %s, using KNN",
@@ -1240,6 +1243,8 @@ bool rewriteMyVectorColumnDef(const string& query, string& newQuery) {
             colinfo = MYVECTOR_DEFAULT_INDEX_TYPE + "," + colinfo;
             vtype = "KNN";
             vo.setOption("type", vtype);
+        } else {
+            transform(vtype.begin(), vtype.end(), vtype.begin(), ::toupper);
         }
 
         if (vo.getOption("dim") == "") {

--- a/tests/test_myvectorbench_compare.py
+++ b/tests/test_myvectorbench_compare.py
@@ -192,3 +192,28 @@ def test_compare_knn_ann_qps_breach(capsys):
     assert rc == 1
     assert "FAIL: one or more metrics exceeded threshold." in captured.out
     assert 'knn_ann_qps' in captured.out
+
+
+def test_compare_recall_null_baseline_skips(capsys):
+    """recall_at_10=None in baseline → N/A row, no breach."""
+    with tempfile.TemporaryDirectory() as tmp:
+        baseline = _make_json(tmp, 'baseline.json', {'recall_at_10': None})
+        current  = _make_json(tmp, 'current.json',  {'recall_at_10': 0.940})
+        cfg = _make_config(tmp, "  recall_at_10: -0.05\n")
+        rc = compare(baseline, current, cfg)
+        captured = capsys.readouterr()
+    assert rc == 0
+    assert 'N/A' in captured.out
+
+
+def test_compare_recall_breach(capsys):
+    """recall_at_10 drops more than -0.05 absolute → FAIL."""
+    with tempfile.TemporaryDirectory() as tmp:
+        baseline = _make_json(tmp, 'baseline.json', {'recall_at_10': 0.942})
+        current  = _make_json(tmp, 'current.json',  {'recall_at_10': 0.880})  # -0.062
+        cfg = _make_config(tmp, "  recall_at_10: -0.05\n")
+        rc = compare(baseline, current, cfg)
+        captured = capsys.readouterr()
+    assert rc == 1
+    assert 'recall_at_10' in captured.out
+    assert 'FAIL' in captured.out


### PR DESCRIPTION
## Summary

- **Issue #92**: `VectorIndexCollection::open()` used a case-sensitive `rfind("type=HNSW")` check. All docs/examples use lowercase `type=hnsw`, causing silent KNN fallback for `online=Y` HNSW tables. Fixed by uppercasing the parsed type value before branching. Same fix applied to `vtype` in `rewriteMyVectorColumnDef`.
- **recall_at_10**: Implements the benchmark metric that has been a `None` stub since myvectorbench shipped. Runs brute-force KNN + `MYVECTOR_IS_ANN` on the same 50 query vectors and measures top-10 overlap. Returns `None` (no breach) when query rewrite is inactive.
- **Issue #93**: Closed — fixed by PR #97 (DDL enforcement via `event_tracking_parse`).

## Test plan

- [x] Pre-release-test.sh: 14 passed, 0 failed on 8.4 and 9.7
- [x] pytest tests/test_myvectorbench_compare.py: 18 passed
- [ ] CI green on all jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark now measures Recall@10 metric to evaluate approximate nearest neighbor search accuracy
  * Added configurable recall query parameter to workload configuration

* **Bug Fixes**
  * Recall@10 threshold validation now fully functional (previously always reported null)

* **Tests**
  * Added coverage for recall@10 threshold comparison logic and validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/askdba/myvector/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->