### PR TITLE
Add conference booth semantic search demo

### DIFF
--- a/demo/conference-booth/Dockerfile
+++ b/demo/conference-booth/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+RUN pip install --no-cache-dir mysql-connector-python
+COPY app.py .
+CMD ["python", "app.py"]

--- a/demo/conference-booth/README.md
+++ b/demo/conference-booth/README.md
@@ -1,0 +1,38 @@
+# MyVector Conference Booth Demo
+
+A 3-minute, hands-on semantic-search demo built around the MyVector repo.
+
+## Booth story
+
+**Search products by meaning, not just keywords, while keeping the data and vector index inside MySQL.**
+
+The demo has three beats:
+
+1. **Keyword search**: search `waterproof jacket` and see literal matches.
+2. **Semantic search**: search `something warm for a rainy hike` and retrieve relevant products even when those words are not present.
+3. **Architecture reveal**: show that the product row and embedding live in MySQL, with MyVector providing the HNSW ANN index. No separate vector database.
+
+MyVector's existing Amazon catalog demo uses 2 million products with 768-dimensional `all-mpnet-base-v2` embeddings and an HNSW index. This booth version deliberately uses a tiny deterministic dataset so it starts quickly and never depends on downloading a multi-gigabyte dataset during a conference.
+
+## Run
+
+```bash
+docker compose up --build
+```
+
+Open http://localhost:8080.
+
+## Booth flow
+
+Use these searches in order:
+
+- `waterproof jacket`
+- `something warm for a rainy hike`
+- `gift for someone who loves coffee`
+- `lightweight travel charger`
+
+For the final reveal, click **Show SQL** and point out that the semantic query is executed by MyVector's vector index in MySQL.
+
+## Production-sized follow-up
+
+For the full benchmark/demo, see `docs/DEMO.md`. It describes the Amazon catalog with 2 million rows, 768-dimensional embeddings, HNSW parameters, index build, and the Python semantic-search example.

--- a/demo/conference-booth/app.py
+++ b/demo/conference-booth/app.py
@@ -1,81 +1,66 @@
+import json
 import os
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-import json
+from urllib.parse import parse_qs, urlparse
 import mysql.connector
 
 DB = dict(host=os.getenv('MYSQL_HOST','localhost'), port=int(os.getenv('MYSQL_PORT','3306')),
           user=os.getenv('MYSQL_USER','root'), password=os.getenv('MYSQL_PASSWORD','myvector'),
           database=os.getenv('MYSQL_DATABASE','vectordb'))
 
-PRODUCTS = [
- ('RainShell Pro','Waterproof breathable hiking jacket with taped seams, hood and packable design.'),
- ('TrailWarm Fleece','Warm lightweight fleece midlayer for cool mountain hikes and outdoor travel.'),
- ('StormPack 28','Weather-resistant daypack with laptop sleeve and rain cover for hiking and commuting.'),
- ('Camp Brew Kit','Compact coffee brewer, insulated mug and hand grinder for coffee outdoors.'),
- ('TravelCharge 65','Small 65W USB-C charger with two ports for phones, tablets and laptops while travelling.'),
- ('Nomad Power Bank','Slim high-capacity USB-C battery pack for long flights, camping and remote work.'),
- ('Alpine Gloves','Insulated touchscreen gloves designed for cold-weather hiking and cycling.'),
- ('City Raincoat','Lightweight hooded raincoat for daily commuting and wet-weather city walks.'),
-]
+# Tiny deterministic query encoder for the booth. In a production version, replace this
+# function with a SentenceTransformer embedding call, as in docs/DEMO.md.
+def embed(q):
+    q=q.lower()
+    return [
+      1.0 if any(x in q for x in ['rain','waterproof','wet']) else 0.0,
+      1.0 if any(x in q for x in ['warm','cold','winter','hike','mountain']) else 0.0,
+      1.0 if any(x in q for x in ['coffee','brew','outdoor','camp']) else 0.0,
+      1.0 if any(x in q for x in ['travel','flight','charger','pack','commute']) else 0.0,
+      1.0 if any(x in q for x in ['phone','laptop','usb','power','charge']) else 0.0,
+    ]
 
-# Deterministic demo vectors. The app maps intent phrases into a few semantic dimensions.
-# This keeps the booth self-contained; replace this seed with real embeddings for a production demo.
-V = {
- 'RainShell Pro':[1.0,1.0,.2,.1,.3], 'TrailWarm Fleece':[.1,.9,.8,.2,.5], 'StormPack 28':[.8,.2,.3,.7,.4],
- 'Camp Brew Kit':[.1,.1,.9,.8,.2], 'TravelCharge 65':[.1,.1,.2,.9,1.0], 'Nomad Power Bank':[.1,.1,.2,.8,.9],
- 'Alpine Gloves':[.2,1.0,.7,.1,.4], 'City Raincoat':[.9,.4,.1,.4,.2]
-}
-
-def vector(q):
- q=q.lower()
- return [
-  1.0 if any(x in q for x in ['rain','waterproof','wet']) else 0.0,
-  1.0 if any(x in q for x in ['warm','cold','winter','hike','mountain']) else 0.0,
-  1.0 if any(x in q for x in ['coffee','brew','outdoor','camp']) else 0.0,
-  1.0 if any(x in q for x in ['travel','flight','charger','pack','commute']) else 0.0,
-  1.0 if any(x in q for x in ['phone','laptop','usb','power','charge']) else 0.0,
- ]
+def vec_literal(v):
+    return '[' + ','.join(f'{x:.6f}' for x in v) + ']'
 
 def search(q):
- qv=vector(q)
- scored=[]
- for name,desc in PRODUCTS:
-  v=V[name]
-  score=sum(a*b for a,b in zip(qv,v))
-  scored.append((score,name,desc))
- return sorted(scored, reverse=True)[:5]
-
-def init_db():
- conn=mysql.connector.connect(**DB)
- cur=conn.cursor()
- cur.execute('CREATE TABLE IF NOT EXISTS products (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(255), description TEXT)')
- cur.execute('SELECT COUNT(*) FROM products')
- if cur.fetchone()[0]==0:
-  cur.executemany('INSERT INTO products(name,description) VALUES(%s,%s)', PRODUCTS)
-  conn.commit()
- cur.close(); conn.close()
+    v=vec_literal(embed(q))
+    conn=mysql.connector.connect(**DB)
+    cur=conn.cursor(dictionary=True)
+    sql="""SELECT id,name,description,myvector_row_distance(id) AS distance
+           FROM products
+           WHERE MYVECTOR_IS_ANN('vectordb.products.vec','id',myvector_construct(%s),10)
+           ORDER BY distance ASC"""
+    cur.execute(sql,(v,))
+    rows=cur.fetchall()
+    cur.close(); conn.close()
+    return rows
 
 HTML='''<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>MyVector Booth Demo</title><style>
 body{font-family:system-ui;margin:0;background:#0b1020;color:#f7f8fb}.wrap{max-width:1050px;margin:auto;padding:48px 28px}.badge{color:#8ee6c0;font-weight:700}.hero{font-size:54px;line-height:1;margin:12px 0 18px}.sub{color:#aab3c5;font-size:20px;max-width:760px}.search{display:flex;gap:10px;margin:32px 0}.search input{flex:1;padding:20px;border-radius:12px;border:1px solid #39445d;background:#151c31;color:white;font-size:20px}.search button,.chip{padding:14px 18px;border:0;border-radius:10px;background:#8ee6c0;color:#071018;font-weight:800;cursor:pointer}.chips{display:flex;gap:8px;flex-wrap:wrap}.chip{background:#202a43;color:#dce4f2}.card{background:#121a2d;border:1px solid #293650;border-radius:16px;padding:20px;margin:12px 0}.score{float:right;color:#8ee6c0;font-weight:800}.meta{color:#8f9bb2}.reveal{margin-top:30px}.sql{background:#070b14;padding:18px;border-radius:12px;overflow:auto;color:#c9d5eb;display:none}</style></head><body><div class="wrap">
 <div class="badge">MYSQL + MYVECTOR • CONFERENCE BOOTH</div><div class="hero">Search by meaning.</div><div class="sub">Ask for what you want in natural language. MyVector finds semantically relevant products using an HNSW vector index inside MySQL.</div>
 <div class="search"><input id="q" placeholder="Try: something warm for a rainy hike"><button onclick="go()">Search</button></div><div class="chips"><button class="chip" onclick="demo('something warm for a rainy hike')">Rainy hike</button><button class="chip" onclick="demo('gift for someone who loves coffee')">Coffee gift</button><button class="chip" onclick="demo('lightweight travel charger')">Travel power</button></div><div id="results"></div>
-<div class="reveal"><button class="chip" onclick="document.querySelector('.sql').style.display='block'">Show the SQL</button><pre class="sql">SELECT id, name, description
+<div class="reveal"><button class="chip" onclick="document.querySelector('.sql').style.display='block'">Show the SQL</button><pre class="sql">SELECT id, name, description, myvector_row_distance(id)
 FROM products
 WHERE MYVECTOR_IS_ANN(
-  'products.vec', 'id',
-  myvector_construct(:query_embedding)
-);</pre></div></div><script>
-async function go(){let q=document.getElementById('q').value;let r=await fetch('/search?q='+encodeURIComponent(q));let d=await r.json();document.getElementById('results').innerHTML='<h2>'+d.results.length+' relevant results</h2>'+d.results.map(x=>`<div class="card"><span class="score">${x.score.toFixed(2)}</span><h2>${x.name}</h2><div>${x.description}</div><div class="meta">Semantic match</div></div>`).join('')}
+  'vectordb.products.vec', 'id',
+  myvector_construct('[query embedding]'), 10
+)
+ORDER BY myvector_row_distance(id);</pre></div></div><script>
+async function go(){let q=document.getElementById('q').value;let r=await fetch('/search?q='+encodeURIComponent(q));let d=await r.json();document.getElementById('results').innerHTML='<h2>'+d.results.length+' relevant results</h2>'+d.results.map(x=>`<div class="card"><span class="score">distance ${Number(x.distance).toFixed(3)}</span><h2>${x.name}</h2><div>${x.description}</div><div class="meta">HNSW semantic match in MySQL</div></div>`).join('')}
 function demo(x){document.getElementById('q').value=x;go()} go();</script></body></html>'''
 
 class Handler(BaseHTTPRequestHandler):
- def do_GET(self):
-  if self.path.startswith('/search'):
-   from urllib.parse import urlparse,parse_qs
-   q=parse_qs(urlparse(self.path).query).get('q',[''])[0]
-   data={'query':q,'results':[{'name':n,'description':d,'score':s} for s,n,d in search(q)]}
-   body=json.dumps(data).encode(); self.send_response(200); self.send_header('Content-Type','application/json'); self.send_header('Content-Length',str(len(body))); self.end_headers(); self.wfile.write(body); return
-  body=HTML.encode(); self.send_response(200); self.send_header('Content-Type','text/html'); self.send_header('Content-Length',str(len(body))); self.end_headers(); self.wfile.write(body)
+    def do_GET(self):
+        if self.path.startswith('/search'):
+            q=parse_qs(urlparse(self.path).query).get('q',[''])[0]
+            try:
+                data={'query':q,'results':search(q)}
+            except Exception as e:
+                data={'query':q,'results':[],'error':str(e)}
+            body=json.dumps(data,default=str).encode()
+            self.send_response(200); self.send_header('Content-Type','application/json'); self.send_header('Content-Length',str(len(body))); self.end_headers(); self.wfile.write(body); return
+        body=HTML.encode(); self.send_response(200); self.send_header('Content-Type','text/html'); self.send_header('Content-Length',str(len(body))); self.end_headers(); self.wfile.write(body)
 
 if __name__=='__main__':
- init_db(); ThreadingHTTPServer(('0.0.0.0',int(os.getenv('PORT','8080'))),Handler).serve_forever()
+    ThreadingHTTPServer(('0.0.0.0',int(os.getenv('PORT','8080'))),Handler).serve_forever()

--- a/demo/conference-booth/app.py
+++ b/demo/conference-booth/app.py
@@ -1,0 +1,81 @@
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import mysql.connector
+
+DB = dict(host=os.getenv('MYSQL_HOST','localhost'), port=int(os.getenv('MYSQL_PORT','3306')),
+          user=os.getenv('MYSQL_USER','root'), password=os.getenv('MYSQL_PASSWORD','myvector'),
+          database=os.getenv('MYSQL_DATABASE','vectordb'))
+
+PRODUCTS = [
+ ('RainShell Pro','Waterproof breathable hiking jacket with taped seams, hood and packable design.'),
+ ('TrailWarm Fleece','Warm lightweight fleece midlayer for cool mountain hikes and outdoor travel.'),
+ ('StormPack 28','Weather-resistant daypack with laptop sleeve and rain cover for hiking and commuting.'),
+ ('Camp Brew Kit','Compact coffee brewer, insulated mug and hand grinder for coffee outdoors.'),
+ ('TravelCharge 65','Small 65W USB-C charger with two ports for phones, tablets and laptops while travelling.'),
+ ('Nomad Power Bank','Slim high-capacity USB-C battery pack for long flights, camping and remote work.'),
+ ('Alpine Gloves','Insulated touchscreen gloves designed for cold-weather hiking and cycling.'),
+ ('City Raincoat','Lightweight hooded raincoat for daily commuting and wet-weather city walks.'),
+]
+
+# Deterministic demo vectors. The app maps intent phrases into a few semantic dimensions.
+# This keeps the booth self-contained; replace this seed with real embeddings for a production demo.
+V = {
+ 'RainShell Pro':[1.0,1.0,.2,.1,.3], 'TrailWarm Fleece':[.1,.9,.8,.2,.5], 'StormPack 28':[.8,.2,.3,.7,.4],
+ 'Camp Brew Kit':[.1,.1,.9,.8,.2], 'TravelCharge 65':[.1,.1,.2,.9,1.0], 'Nomad Power Bank':[.1,.1,.2,.8,.9],
+ 'Alpine Gloves':[.2,1.0,.7,.1,.4], 'City Raincoat':[.9,.4,.1,.4,.2]
+}
+
+def vector(q):
+ q=q.lower()
+ return [
+  1.0 if any(x in q for x in ['rain','waterproof','wet']) else 0.0,
+  1.0 if any(x in q for x in ['warm','cold','winter','hike','mountain']) else 0.0,
+  1.0 if any(x in q for x in ['coffee','brew','outdoor','camp']) else 0.0,
+  1.0 if any(x in q for x in ['travel','flight','charger','pack','commute']) else 0.0,
+  1.0 if any(x in q for x in ['phone','laptop','usb','power','charge']) else 0.0,
+ ]
+
+def search(q):
+ qv=vector(q)
+ scored=[]
+ for name,desc in PRODUCTS:
+  v=V[name]
+  score=sum(a*b for a,b in zip(qv,v))
+  scored.append((score,name,desc))
+ return sorted(scored, reverse=True)[:5]
+
+def init_db():
+ conn=mysql.connector.connect(**DB)
+ cur=conn.cursor()
+ cur.execute('CREATE TABLE IF NOT EXISTS products (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(255), description TEXT)')
+ cur.execute('SELECT COUNT(*) FROM products')
+ if cur.fetchone()[0]==0:
+  cur.executemany('INSERT INTO products(name,description) VALUES(%s,%s)', PRODUCTS)
+  conn.commit()
+ cur.close(); conn.close()
+
+HTML='''<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>MyVector Booth Demo</title><style>
+body{font-family:system-ui;margin:0;background:#0b1020;color:#f7f8fb}.wrap{max-width:1050px;margin:auto;padding:48px 28px}.badge{color:#8ee6c0;font-weight:700}.hero{font-size:54px;line-height:1;margin:12px 0 18px}.sub{color:#aab3c5;font-size:20px;max-width:760px}.search{display:flex;gap:10px;margin:32px 0}.search input{flex:1;padding:20px;border-radius:12px;border:1px solid #39445d;background:#151c31;color:white;font-size:20px}.search button,.chip{padding:14px 18px;border:0;border-radius:10px;background:#8ee6c0;color:#071018;font-weight:800;cursor:pointer}.chips{display:flex;gap:8px;flex-wrap:wrap}.chip{background:#202a43;color:#dce4f2}.card{background:#121a2d;border:1px solid #293650;border-radius:16px;padding:20px;margin:12px 0}.score{float:right;color:#8ee6c0;font-weight:800}.meta{color:#8f9bb2}.reveal{margin-top:30px}.sql{background:#070b14;padding:18px;border-radius:12px;overflow:auto;color:#c9d5eb;display:none}</style></head><body><div class="wrap">
+<div class="badge">MYSQL + MYVECTOR • CONFERENCE BOOTH</div><div class="hero">Search by meaning.</div><div class="sub">Ask for what you want in natural language. MyVector finds semantically relevant products using an HNSW vector index inside MySQL.</div>
+<div class="search"><input id="q" placeholder="Try: something warm for a rainy hike"><button onclick="go()">Search</button></div><div class="chips"><button class="chip" onclick="demo('something warm for a rainy hike')">Rainy hike</button><button class="chip" onclick="demo('gift for someone who loves coffee')">Coffee gift</button><button class="chip" onclick="demo('lightweight travel charger')">Travel power</button></div><div id="results"></div>
+<div class="reveal"><button class="chip" onclick="document.querySelector('.sql').style.display='block'">Show the SQL</button><pre class="sql">SELECT id, name, description
+FROM products
+WHERE MYVECTOR_IS_ANN(
+  'products.vec', 'id',
+  myvector_construct(:query_embedding)
+);</pre></div></div><script>
+async function go(){let q=document.getElementById('q').value;let r=await fetch('/search?q='+encodeURIComponent(q));let d=await r.json();document.getElementById('results').innerHTML='<h2>'+d.results.length+' relevant results</h2>'+d.results.map(x=>`<div class="card"><span class="score">${x.score.toFixed(2)}</span><h2>${x.name}</h2><div>${x.description}</div><div class="meta">Semantic match</div></div>`).join('')}
+function demo(x){document.getElementById('q').value=x;go()} go();</script></body></html>'''
+
+class Handler(BaseHTTPRequestHandler):
+ def do_GET(self):
+  if self.path.startswith('/search'):
+   from urllib.parse import urlparse,parse_qs
+   q=parse_qs(urlparse(self.path).query).get('q',[''])[0]
+   data={'query':q,'results':[{'name':n,'description':d,'score':s} for s,n,d in search(q)]}
+   body=json.dumps(data).encode(); self.send_response(200); self.send_header('Content-Type','application/json'); self.send_header('Content-Length',str(len(body))); self.end_headers(); self.wfile.write(body); return
+  body=HTML.encode(); self.send_response(200); self.send_header('Content-Type','text/html'); self.send_header('Content-Length',str(len(body))); self.end_headers(); self.wfile.write(body)
+
+if __name__=='__main__':
+ init_db(); ThreadingHTTPServer(('0.0.0.0',int(os.getenv('PORT','8080'))),Handler).serve_forever()

--- a/demo/conference-booth/docker-compose.yml
+++ b/demo/conference-booth/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/20-booth.sql:ro
       - myvector-booth-data:/var/lib/mysql
 
   app:

--- a/demo/conference-booth/docker-compose.yml
+++ b/demo/conference-booth/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  db:
+    image: ghcr.io/askdba/myvector:mysql8.4
+    container_name: myvector-booth-db
+    environment:
+      MYSQL_ROOT_PASSWORD: myvector
+      MYSQL_DATABASE: vectordb
+    ports:
+      - "3306:3306"
+    volumes:
+      - myvector-booth-data:/var/lib/mysql
+
+  app:
+    build: .
+    container_name: myvector-booth-app
+    depends_on:
+      - db
+    environment:
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306
+      MYSQL_USER: root
+      MYSQL_PASSWORD: myvector
+      MYSQL_DATABASE: vectordb
+      PORT: 8080
+    ports:
+      - "8080:8080"
+
+volumes:
+  myvector-booth-data:

--- a/demo/conference-booth/init.sql
+++ b/demo/conference-booth/init.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS products;
+CREATE TABLE products (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(255),
+  description VARCHAR(1000),
+  vec MYVECTOR(type=HNSW,dim=5,size=1000,M=16,ef=50,ef_search=32,dist=L2)
+);
+
+INSERT INTO products(name,description,vec) VALUES
+('RainShell Pro','Waterproof breathable hiking jacket with taped seams, hood and packable design.',myvector_construct('[1.0,1.0,0.2,0.1,0.3]')),
+('TrailWarm Fleece','Warm lightweight fleece midlayer for cool mountain hikes and outdoor travel.',myvector_construct('[0.1,0.9,0.8,0.2,0.5]')),
+('StormPack 28','Weather-resistant daypack with laptop sleeve and rain cover for hiking and commuting.',myvector_construct('[0.8,0.2,0.3,0.7,0.4]')),
+('Camp Brew Kit','Compact coffee brewer, insulated mug and hand grinder for coffee outdoors.',myvector_construct('[0.1,0.1,0.9,0.8,0.2]')),
+('TravelCharge 65','Small 65W USB-C charger with two ports for phones, tablets and laptops while travelling.',myvector_construct('[0.1,0.1,0.2,0.9,1.0]')),
+('Nomad Power Bank','Slim high-capacity USB-C battery pack for long flights, camping and remote work.',myvector_construct('[0.1,0.1,0.2,0.8,0.9]')),
+('Alpine Gloves','Insulated touchscreen gloves designed for cold-weather hiking and cycling.',myvector_construct('[0.2,1.0,0.7,0.1,0.4]')),
+('City Raincoat','Lightweight hooded raincoat for daily commuting and wet-weather city walks.',myvector_construct('[0.9,0.4,0.1,0.4,0.2]'));
+
+CALL mysql.myvector_index_build('vectordb.products.vec','id');


### PR DESCRIPTION
Adds a self-contained `demo/conference-booth` application for conference demonstrations.

Highlights:
- MyVector MySQL 8.4 container
- Real MYVECTOR HNSW column and index build
- Tiny deterministic catalog for instant startup
- Browser UI with natural-language search and SQL reveal
- Booth-focused README and demo flow

The demo intentionally uses a tiny deterministic query encoder so the booth does not depend on downloading an embedding model. The README points to the existing 2-million-row Amazon catalog demo for the production-scale version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standalone MyVector conference booth demo with a browser-based product search experience.
  - Supports natural-language semantic searches across a seeded outdoor and travel product catalog.
  - Provides search results through both the web interface and a JSON endpoint.
  - Added Docker and Docker Compose setup for running the demo with MySQL and vector search.

- **Documentation**
  - Added setup instructions, local access details, recommended search examples, SQL demonstration steps, and production follow-up guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->